### PR TITLE
feat: support batch inserts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/kwilteam/kwil-db/core v0.2.2-0.20240731225936-dc8d6befe577
 	github.com/pkg/errors v0.9.1
-	github.com/trufnetwork/sdk-go v0.1.1-0.20250106185816-f6579e21b5a3
+	github.com/trufnetwork/sdk-go v0.1.1-0.20250121180308-4c28f05a8499
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/kwilteam/kwil-db/core v0.2.2-0.20240731225936-dc8d6befe577
 	github.com/pkg/errors v0.9.1
-	github.com/trufnetwork/sdk-go v0.1.1-0.20250121180308-4c28f05a8499
+	github.com/trufnetwork/sdk-go v0.1.1-0.20250121184707-3a141ca16bcb
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/trufnetwork/sdk-go v0.1.1-0.20250106185816-f6579e21b5a3 h1:x+gn93Up1Y
 github.com/trufnetwork/sdk-go v0.1.1-0.20250106185816-f6579e21b5a3/go.mod h1:xfGmTkamZxyAOG331+P2oceLFxR7u/4lIoELyYEeCR4=
 github.com/trufnetwork/sdk-go v0.1.1-0.20250121180308-4c28f05a8499 h1:mhcUSGOTpkQUKJzWx5SG/P0l6jWgmsN4bh/6dB3x96U=
 github.com/trufnetwork/sdk-go v0.1.1-0.20250121180308-4c28f05a8499/go.mod h1:xfGmTkamZxyAOG331+P2oceLFxR7u/4lIoELyYEeCR4=
+github.com/trufnetwork/sdk-go v0.1.1-0.20250121184707-3a141ca16bcb h1:+0jQxkAoHsuUHIc+F/AOfR7VL8rPum4oBbIdSL1J4ms=
+github.com/trufnetwork/sdk-go v0.1.1-0.20250121184707-3a141ca16bcb/go.mod h1:xfGmTkamZxyAOG331+P2oceLFxR7u/4lIoELyYEeCR4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/go.sum
+++ b/go.sum
@@ -150,6 +150,8 @@ github.com/trufnetwork/sdk-go v0.1.1-0.20250106182118-51a3555c1dde h1:0tV3Y2k0xp
 github.com/trufnetwork/sdk-go v0.1.1-0.20250106182118-51a3555c1dde/go.mod h1:xfGmTkamZxyAOG331+P2oceLFxR7u/4lIoELyYEeCR4=
 github.com/trufnetwork/sdk-go v0.1.1-0.20250106185816-f6579e21b5a3 h1:x+gn93Up1YuLY3mys+/YgFxaFqOTeEs3atpPM95U/aQ=
 github.com/trufnetwork/sdk-go v0.1.1-0.20250106185816-f6579e21b5a3/go.mod h1:xfGmTkamZxyAOG331+P2oceLFxR7u/4lIoELyYEeCR4=
+github.com/trufnetwork/sdk-go v0.1.1-0.20250121180308-4c28f05a8499 h1:mhcUSGOTpkQUKJzWx5SG/P0l6jWgmsN4bh/6dB3x96U=
+github.com/trufnetwork/sdk-go v0.1.1-0.20250121180308-4c28f05a8499/go.mod h1:xfGmTkamZxyAOG331+P2oceLFxR7u/4lIoELyYEeCR4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -31,8 +31,14 @@ class TNClient:
 
     def _coalesce_int(self, val: Optional[int], default: int = -1) -> int:
         """
-        Helper to coalesce an optional integer into a sentinel value (default=-1).
-        If val is None, return default; otherwise return val.
+        Helper to coalesce an optional integer into a sentinel value.
+        
+        Args:
+            val: The optional integer value
+            default: The default value to use if val is None (-1 by default)
+            
+        Returns:
+            The non-None integer value
         """
         return val if val is not None else default
 
@@ -41,6 +47,12 @@ class TNClient:
     ) -> List[Dict[str, Any]]:
         """
         Helper to convert a Go slice of maps into a Python list of dicts.
+        
+        Args:
+            go_slice: The Go slice object returned from the bindings
+            
+        Returns:
+            A list of Python dictionaries
         """
         result = []
         for record in go_slice:
@@ -125,6 +137,9 @@ class TNClient:
         Each record is expected to have:
           - "date": str (YYYY-MM-DD) 
           - "value": float or int
+
+        Note: Do not use this for inserting multiple records rapidly. Use batch inserts instead.
+        Or else you can have nonce errors.
         """
         dates = [record["date"] for record in records]
         values = [record["value"] for record in records]
@@ -147,6 +162,9 @@ class TNClient:
     ) -> str:
         """
         Insert records into a stream with the given stream ID using Unix timestamps.
+
+        Note: Do not use this for inserting multiple records rapidly. Use batch inserts instead.
+        Or else you can have nonce errors.
         """
         dates = [record["date"] for record in records]
         values = [record["value"] for record in records]

--- a/tests/test_sequential_inserts.py
+++ b/tests/test_sequential_inserts.py
@@ -1,0 +1,211 @@
+import pytest
+import time
+from trufnetwork_sdk_py.client import TNClient, UnixRecordBatch, UnixRecord
+from trufnetwork_sdk_py.utils import generate_stream_id
+import trufnetwork_sdk_c_bindings.exports as truf_sdk
+from typing import List
+
+# Test configuration
+TEST_PROVIDER_URL = "http://localhost:8484"  
+TEST_PRIVATE_KEY = (
+    "0121234567890123456789012345678901234567890123456789012345178901"
+)
+
+@pytest.fixture(scope="module")
+def client():
+    """
+    Pytest fixture to create a TNClient instance for testing.
+    """
+    client = TNClient(TEST_PROVIDER_URL, TEST_PRIVATE_KEY)
+    return client
+
+def test_batch_small_batches(client):
+    """
+    Test inserting 20 small batches of records (5 records each) in a single batch call.
+    """
+    stream_id = generate_stream_id("test_batch_small")
+
+    try:
+        client.destroy_stream(stream_id)
+    except Exception:
+        pass
+
+    client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitiveUnix)
+    client.init_stream(stream_id)
+
+    try:
+        NUM_BATCHES = 500
+        RECORDS_PER_BATCH = 5
+
+        # Time the insertions
+        insert_start = time.time()
+        
+        # Prepare all batches
+        batches: List[UnixRecordBatch] = []
+        for batch in range(NUM_BATCHES):
+            base_timestamp = 1672531200 + (batch * 86400)  # Start from 2023-01-01
+            records = [
+                UnixRecord(
+                    date=base_timestamp + (i * 3600),
+                    value=float(batch * 100 + i)
+                )
+                for i in range(RECORDS_PER_BATCH)
+            ]
+            batches.append(UnixRecordBatch(
+                stream_id=stream_id,
+                inputs=records
+            ))
+        
+        # Insert all batches at once
+        tx_hashes = client.batch_insert_records_unix(batches, wait=False)
+        assert len(tx_hashes) == NUM_BATCHES
+
+        insert_duration = time.time() - insert_start
+        print(f"[Small Batches] All insertions completed in {insert_duration:.2f}s "
+              f"(avg {(insert_duration/NUM_BATCHES)*1000:.2f}ms per batch, "
+              f"{(insert_duration/(NUM_BATCHES*RECORDS_PER_BATCH))*1000:.2f}ms per record)")
+
+        # Time the confirmations
+        confirm_start = time.time()
+        
+        # Wait for all transactions after sending them all
+        for tx_hash in tx_hashes:
+            client.wait_for_tx(tx_hash)
+
+        confirm_duration = time.time() - confirm_start
+        print(f"[Small Batches] All transactions confirmed in {confirm_duration:.2f}s")
+
+        # Verify total number of records
+        total_records = NUM_BATCHES * RECORDS_PER_BATCH
+        retrieved_records = client.get_records_unix(
+            stream_id,
+            date_from=1672531200,
+            date_to=1672531200 + (NUM_BATCHES * 86400)
+        )
+        assert len(retrieved_records) == total_records
+
+    finally:
+        client.destroy_stream(stream_id)
+
+def test_batch_large_batches(client):
+    """
+    Test inserting 5 large batches of records (100 records each) in a single batch call.
+    """
+    stream_id = generate_stream_id("test_batch_large")
+
+    try:
+        client.destroy_stream(stream_id)
+    except Exception:
+        pass
+
+    client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitiveUnix)
+    client.init_stream(stream_id)
+
+    try:
+        NUM_BATCHES = 500
+        RECORDS_PER_BATCH = 100
+
+        # Time the insertions
+        insert_start = time.time()
+        
+        # Prepare all batches
+        batches: List[UnixRecordBatch] = []
+        for batch in range(NUM_BATCHES):
+            base_timestamp = 1672531200 + (batch * 86400)
+            records = [
+                UnixRecord(
+                    date=base_timestamp + (i * 300),  # 5-minute intervals
+                    value=float(batch * 1000 + i)
+                )
+                for i in range(RECORDS_PER_BATCH)
+            ]
+            batches.append(UnixRecordBatch(
+                stream_id=stream_id,
+                inputs=records
+            ))
+        
+        # Insert all batches at once
+        tx_hashes = client.batch_insert_records_unix(batches, wait=False)
+        assert len(tx_hashes) == NUM_BATCHES
+
+        insert_duration = time.time() - insert_start
+        print(f"[Large Batches] All insertions completed in {insert_duration:.2f}s "
+              f"(avg {(insert_duration/NUM_BATCHES)*1000:.2f}ms per batch, "
+              f"{(insert_duration/(NUM_BATCHES*RECORDS_PER_BATCH))*1000:.2f}ms per record)")
+
+        # Time the confirmations
+        confirm_start = time.time()
+        
+        # Wait for all transactions after sending them all
+        for tx_hash in tx_hashes:
+            client.wait_for_tx(tx_hash)
+
+        confirm_duration = time.time() - confirm_start
+        print(f"[Large Batches] All transactions confirmed in {confirm_duration:.2f}s")
+
+        # Verify total number of records
+        total_records = NUM_BATCHES * RECORDS_PER_BATCH
+        retrieved_records = client.get_records_unix(
+            stream_id,
+            date_from=1672531200,
+            date_to=1672531200 + (NUM_BATCHES * 86400)
+        )
+        assert len(retrieved_records) == total_records
+
+    finally:
+        client.destroy_stream(stream_id)
+
+def test_batch_single_record_inserts(client):
+    """
+    Test inserting individual records in a single batch call.
+    """
+    stream_id = generate_stream_id("test_batch_singles")
+
+    try:
+        client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitiveUnix)
+        client.init_stream(stream_id)
+        NUM_RECORDS = 500
+
+        # Time the insertions
+        insert_start = time.time()
+        
+        # Prepare all records as individual batches
+        base_timestamp = 1672531200
+        batches: List[UnixRecordBatch] = []
+        for i in range(NUM_RECORDS):
+            batches.append(UnixRecordBatch(
+                stream_id=stream_id,
+                inputs=[UnixRecord(
+                    date=base_timestamp + (i * 3600),
+                    value=float(i)
+                )]
+            ))
+        
+        # Insert all records at once
+        tx_hashes = client.batch_insert_records_unix(batches, wait=False)
+        assert len(tx_hashes) == NUM_RECORDS
+
+        insert_duration = time.time() - insert_start
+        print(f"[Single Records] All insertions completed in {insert_duration:.2f}s "
+              f"(avg {(insert_duration/NUM_RECORDS)*1000:.2f}ms per record)")
+
+        # Time the confirmations
+        confirm_start = time.time()
+        
+        # Wait for all transactions after sending them all
+        for tx_hash in tx_hashes:
+            client.wait_for_tx(tx_hash)
+
+        confirm_duration = time.time() - confirm_start
+        print(f"[Single Records] All transactions confirmed in {confirm_duration:.2f}s")
+
+        # Verify all records were inserted
+        retrieved_records = client.get_records_unix(
+            stream_id,
+            date_from=base_timestamp,
+            date_to=base_timestamp + (NUM_RECORDS * 3600)
+        )
+        assert len(retrieved_records) == NUM_RECORDS
+
+    finally:
+        client.destroy_stream(stream_id) 

--- a/tests/test_sequential_inserts.py
+++ b/tests/test_sequential_inserts.py
@@ -57,7 +57,7 @@ def test_batch_small_batches(client):
             ))
         
         # Insert all batches at once
-        tx_hashes = client.batch_insert_records_unix(batches, wait=False)
+        tx_hashes = client.batch_insert_records_unix(batches, wait=False)['tx_hashes']
         assert len(tx_hashes) == NUM_BATCHES
 
         insert_duration = time.time() - insert_start
@@ -125,7 +125,7 @@ def test_batch_large_batches(client):
             ))
         
         # Insert all batches at once
-        tx_hashes = client.batch_insert_records_unix(batches, wait=False)
+        tx_hashes = client.batch_insert_records_unix(batches, wait=False)['tx_hashes']
         assert len(tx_hashes) == NUM_BATCHES
 
         insert_duration = time.time() - insert_start
@@ -182,7 +182,7 @@ def test_batch_single_record_inserts(client):
             ))
         
         # Insert all records at once
-        tx_hashes = client.batch_insert_records_unix(batches, wait=False)
+        tx_hashes = client.batch_insert_records_unix(batches, wait=False)['tx_hashes']
         assert len(tx_hashes) == NUM_RECORDS
 
         insert_duration = time.time() - insert_start


### PR DESCRIPTION
- Added GetCurrentAccount and GetNextNonce functions in bindings.go to retrieve account details and nonce for transaction management.
- Introduced UnixBatch and related helper functions for creating and managing batches of records in bindings.go.
- Implemented BatchInsertRecordsUnix function to handle batch insertion of records using Unix timestamps.
- Enhanced the Python TNClient with batch_insert_records_unix method for inserting multiple batches of records efficiently.
- Added comprehensive unit tests in test_sequential_inserts.py to validate batch insertion functionality for small, large, and single record scenarios.

These changes improve the SDK's capability to handle batch operations, enhancing performance and usability for users working with Unix timestamp records.