### PR TITLE
feat: Add non-Unix record batch insertion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = []
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",
+    "pytest-mock>=3.14.0",
+    "requests>=2.31.0"
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+# conftest.py
+
+from glob import glob
+
+
+def refactor(string: str) -> str:
+    return string.replace("/", ".").replace("\\", ".").replace(".py", "")
+
+
+pytest_plugins = [refactor(fixture) for fixture in glob("tests/fixtures/*.py") if "__" not in fixture]

--- a/tests/fixtures/test_trufnetwork.py
+++ b/tests/fixtures/test_trufnetwork.py
@@ -1,0 +1,398 @@
+from dataclasses import dataclass, field
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+import pytest
+
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Define the network name to use
+NETWORK_NAME = "tsn_network"
+
+
+@dataclass
+class ContainerSpec:
+    """Configuration for a docker container"""
+
+    name: str
+    image: str
+    tmpfs_path: Optional[str] = None
+    env_vars: list[str] = field(default_factory=list)
+    ports: dict[str, str] = field(default_factory=dict)
+    entrypoint: Optional[str] = None
+    args: list[str] = field(default_factory=list)
+
+    def __post_init__(self):
+        if self.env_vars is None:
+            self.env_vars = []
+        if self.ports is None:
+            self.ports = {}
+        if self.args is None:
+            self.args = []
+
+
+# Container specifications
+POSTGRES_CONTAINER = ContainerSpec(
+    name="test-kwil-postgres",
+    image="kwildb/postgres:latest",
+    tmpfs_path="/var/lib/postgresql/data",
+    env_vars=["POSTGRES_HOST_AUTH_METHOD=trust"],
+)
+
+TSN_DB_CONTAINER = ContainerSpec(
+    name="test-tsn-db",
+    image="tsn-db:local",
+    tmpfs_path="/root/.kwild",
+    entrypoint="/app/kwild",
+    args=[
+        "--autogen",
+        "--app.pg-db-host",
+        "test-kwil-postgres",
+        "--app.hostname",
+        "test-tsn-db",
+        "--chain.p2p.external-address",
+        "http://test-tsn-db:26656",
+        "--chain.consensus.timeout-propose",
+        "100ms",
+        "--chain.consensus.timeout-prevote",
+        "100ms",
+        "--chain.consensus.timeout-precommit",
+        "100ms",
+        "--chain.consensus.timeout-commit",
+        "100ms",
+    ],
+    env_vars=[
+        "CONFIG_PATH=/root/.kwild",
+        "KWILD_APP_HOSTNAME=test-tsn-db",
+        "KWILD_APP_PG_DB_HOST=test-kwil-postgres",
+        "KWILD_APP_PG_DB_PORT=5432",
+        "KWILD_APP_PG_DB_USER=postgres",
+        "KWILD_APP_PG_DB_PASSWORD=",
+        "KWILD_APP_PG_DB_NAME=postgres",
+        "KWILD_CHAIN_P2P_EXTERNAL_ADDRESS=http://test-tsn-db:26656",
+    ],
+    ports={"50051": "50051", "50151": "50151", "8080": "8080", "8484": "8484", "26656": "26656", "26657": "26657"},
+)
+
+
+def run_docker_command(args: list[str], check: bool = False) -> subprocess.CompletedProcess:
+    """
+    Executes a docker command with the given list of arguments.
+
+    Args:
+        args: List of command arguments to pass to docker
+        check: If True, raises CalledProcessError on non-zero exit status
+
+    Returns:
+        CompletedProcess instance with command output
+
+    Raises:
+        subprocess.CalledProcessError: If check=True and command returns non-zero exit status
+    """
+    command = ["docker", *args]
+    logger.debug(f"Running docker command: {' '.join(command)}")
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=check)
+        if result.stderr:
+            logger.debug(f"Docker command stderr: {result.stderr}")
+        return result
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Docker command failed: {e.stderr}")
+        raise
+
+
+def wait_for_postgres_health(max_attempts: int = 30) -> bool:
+    """
+    Wait for postgres container to be healthy
+
+    Args:
+        max_attempts: Maximum number of health check attempts
+
+    Returns:
+        bool: True if postgres becomes healthy, False otherwise
+    """
+    for i in range(max_attempts):
+        try:
+            result = run_docker_command(["exec", POSTGRES_CONTAINER.name, "pg_isready", "-U", "postgres"])
+            if result.returncode == 0:
+                logger.info(f"Postgres is healthy after {i+1} attempts")
+                return True
+            logger.debug(f"Postgres not ready (attempt {i+1}/{max_attempts}): {result.stderr}")
+        except Exception as e:
+            logger.error(f"Error checking postgres health: {e!s}")
+        time.sleep(1)
+    return False
+
+
+def wait_for_tsn_health(max_attempts: int = 10) -> bool:
+    """
+    Wait for TSN-DB node to be healthy and produce first block
+
+    Args:
+        max_attempts: Maximum number of health check attempts
+
+    Returns:
+        bool: True if TSN-DB becomes healthy, False otherwise
+    """
+    import requests
+
+    for i in range(max_attempts):
+        try:
+            logger.info(f"Checking TSN-DB health (attempt {i+1}/{max_attempts})")
+            response = requests.get("http://localhost:8484/api/v1/health")
+            if response.status_code == 200:
+                data = response.json()
+                if data.get("healthy") and data.get("services").get("user").get("block_height") >= 1:
+                    logger.info(f"TSN-DB is healthy after {i+1} attempts")
+                    logger.debug(f"Health check response: {json.dumps(data, indent=2)}")
+                    return True
+            logger.debug(f"TSN-DB not healthy yet (attempt {i+1}/{max_attempts}): {response.text}")
+        except Exception as e:
+            logger.debug(f"Error checking TSN-DB health (attempt {i+1}/{max_attempts}): {e!s}")
+        time.sleep(1)
+    return False
+
+
+def start_container(spec: ContainerSpec, network: str) -> bool:
+    """
+    Start a docker container with the given specification
+
+    Args:
+        spec: Container specification
+        network: Docker network name
+
+    Returns:
+        bool: True if container starts successfully, False otherwise
+    """
+    # First ensure container doesn't exist
+    run_docker_command(["rm", "-f", spec.name])
+
+    args = ["run", "--rm", "--name", spec.name, "--network", network, "-d"]
+
+    if spec.tmpfs_path:
+        args.extend(["--tmpfs", spec.tmpfs_path])
+
+    for env in spec.env_vars:
+        args.extend(["-e", env])
+
+    for host_port, container_port in spec.ports.items():
+        args.extend(["-p", f"{host_port}:{container_port}"])
+
+    if spec.entrypoint:
+        args.extend(["--entrypoint", spec.entrypoint])
+
+    args.append(spec.image)
+
+    if spec.args:
+        args.extend(spec.args)
+
+    try:
+        run_docker_command(args, check=True)
+        logger.info(f"Successfully started container {spec.name}")
+
+        # Get container logs
+        time.sleep(2)  # Wait a bit for container to initialize
+        logs = run_docker_command(["logs", spec.name])
+        logger.debug(f"Container logs for {spec.name}:")
+        logger.debug(logs.stdout)
+        if logs.stderr:
+            logger.debug(f"Container stderr: {logs.stderr}")
+        return True
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to start container {spec.name}: {e.stderr}")
+        return False
+
+
+def stop_container(name: str) -> bool:
+    """
+    Stop a docker container
+
+    Args:
+        name: Name of the container to stop
+
+    Returns:
+        bool: True if container stops successfully, False otherwise
+    """
+    logger.info(f"Stopping container {name}...")
+    try:
+        run_docker_command(["stop", name], check=True)
+        logger.info(f"Successfully stopped container {name}")
+        return True
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to stop container {name}: {e.stderr}")
+        return False
+    finally:
+        # Clean up config dir if it exists
+        if name == TSN_DB_CONTAINER.name and hasattr(TSN_DB_CONTAINER, "_config_dir"):
+            shutil.rmtree(getattr(TSN_DB_CONTAINER, "_config_dir"), ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def docker_network():
+    """
+    Pytest fixture to set up and tear down a Docker network.
+
+    Setup:
+      - Attempts to remove any existing network with the same name
+      - Creates a new network using: docker network create <NETWORK_NAME>
+
+    Teardown:
+      - Removes the network using: docker network rm <NETWORK_NAME>
+
+    Returns:
+        str: The name of the created network
+
+    Raises:
+        pytest.FixureError: If network creation fails
+    """
+    logger.info("Setting up docker network...")
+    # Remove existing network (ignore errors)
+    run_docker_command(["network", "rm", NETWORK_NAME])
+
+    # Create the new network
+    try:
+        run_docker_command(["network", "create", NETWORK_NAME], check=True)
+        logger.info(f"Docker network '{NETWORK_NAME}' created.")
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to create docker network '{NETWORK_NAME}': {e.stderr}")
+        pytest.fail(f"Failed to create docker network '{NETWORK_NAME}': {e.stderr}")
+
+    try:
+        yield NETWORK_NAME
+    finally:
+        logger.info("Tearing down docker network...")
+        run_docker_command(["network", "rm", NETWORK_NAME])
+        logger.info(f"Docker network '{NETWORK_NAME}' removed.")
+
+
+@pytest.fixture(scope="session")
+def tn_node(docker_network):
+    """
+    Pytest fixture that sets up a TSN-DB node with Postgres for testing.
+
+    This fixture:
+    1. Starts a Postgres container
+    2. Waits for Postgres to be healthy
+    3. Starts the TSN-DB node
+    4. Waits for the node to be healthy and produce its first block
+    5. Cleans up both containers after tests
+
+    Args:
+        docker_network: The docker network fixture
+
+    Returns:
+        str: The API endpoint URL for the TSN-DB node
+
+    Raises:
+        pytest.FixureError: If container setup fails
+    """
+    logger.info("Starting Postgres container...")
+    if not start_container(POSTGRES_CONTAINER, docker_network):
+        pytest.fail("Failed to start Postgres container")
+
+    logger.info("Waiting for Postgres to be healthy...")
+    if not wait_for_postgres_health():
+        stop_container(POSTGRES_CONTAINER.name)
+        pytest.fail("Postgres failed to become healthy")
+
+    logger.info("Starting TSN-DB container...")
+    if not start_container(TSN_DB_CONTAINER, docker_network):
+        stop_container(POSTGRES_CONTAINER.name)
+        pytest.fail("Failed to start TSN-DB container")
+
+    logger.info("Waiting for TSN-DB node to be healthy...")
+    if not wait_for_tsn_health():
+        stop_container(TSN_DB_CONTAINER.name)
+        stop_container(POSTGRES_CONTAINER.name)
+        pytest.fail("TSN-DB node failed to become healthy")
+
+    try:
+        yield "http://localhost:8484"
+    finally:
+        logger.info("Cleaning up containers...")
+        stop_container(TSN_DB_CONTAINER.name)
+        stop_container(POSTGRES_CONTAINER.name)
+
+
+class TrufNetworkProvider:
+    """Provider class for interacting with the TrufNetwork node"""
+
+    def __init__(self, api_endpoint: str = "http://localhost:8484"):
+        """
+        Initialize the provider
+
+        Args:
+            api_endpoint: The API endpoint URL for the TSN node
+        """
+        self.api_endpoint = api_endpoint
+        self.provider = self
+
+    def get_provider(self):
+        """Get the provider instance"""
+        return self.provider
+
+
+@pytest.fixture(scope="session")
+def tn_provider(tn_node) -> TrufNetworkProvider:
+    """
+    Returns a TrufNetworkProvider instance configured to use the test TSN node.
+
+    Args:
+        tn_node: The TSN node fixture providing the API endpoint
+
+    Returns:
+        TrufNetworkProvider: Configured provider instance
+    """
+    return TrufNetworkProvider(api_endpoint=tn_node)
+
+
+# Skip these tests on CI environment
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Local development fixture tests, skipped in CI")
+class TestTrufNetworkFixtures:
+    """
+    Test suite for TrufNetwork fixtures.
+
+    These tests verify the fixture setup/teardown behavior.
+    Only run locally, skipped in CI.
+    """
+
+    def test_docker_network_fixture(self, docker_network):
+        """Test docker network creation and cleanup"""
+        # Check network exists
+        result = run_docker_command(["network", "inspect", docker_network])
+        assert result.returncode == 0, "Docker network should exist during test"
+
+    def test_tsn_node_fixture(self, tn_node):
+        """Test TSN node setup and health"""
+        import requests
+
+        # Verify endpoint is accessible
+        response = requests.get(f"{tn_node}/api/v1/health")
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data.get("healthy") is True
+        assert data.get("services").get("user").get("block_height") >= 1
+
+        # Verify containers are running
+        for container in [POSTGRES_CONTAINER.name, TSN_DB_CONTAINER.name]:
+            result = run_docker_command(["container", "inspect", container])
+            assert result.returncode == 0, f"Container {container} should be running"
+
+    def test_tn_provider_fixture(self, tn_provider):
+        """Test TrufNetworkProvider configuration"""
+        assert isinstance(tn_provider, TrufNetworkProvider)
+        assert tn_provider.api_endpoint.startswith("http://")
+        assert tn_provider.get_provider() is tn_provider
+
+DEFAULT_TN_PRIVATE_KEY = "0" * 63 + "1"  # 64 zeros ending with 1
+
+

--- a/tests/test_sequential_inserts.py
+++ b/tests/test_sequential_inserts.py
@@ -1,22 +1,19 @@
 import pytest
 import time
-from trufnetwork_sdk_py.client import TNClient, UnixRecordBatch, UnixRecord
+from trufnetwork_sdk_py.client import TNClient, UnixRecordBatch, UnixRecord, RecordBatch, Record
 from trufnetwork_sdk_py.utils import generate_stream_id
 import trufnetwork_sdk_c_bindings.exports as truf_sdk
 from typing import List
-
-# Test configuration
-TEST_PROVIDER_URL = "http://localhost:8484"  
-TEST_PRIVATE_KEY = (
-    "0121234567890123456789012345678901234567890123456789012345178901"
-)
+from tests.fixtures.test_trufnetwork import DEFAULT_TN_PRIVATE_KEY
+from datetime import datetime, timedelta  # Import datetime and timedelta
 
 @pytest.fixture(scope="module")
-def client():
+def client(tn_node):
     """
     Pytest fixture to create a TNClient instance for testing.
+    Uses the tn_node fixture which provides a running test environment.
     """
-    client = TNClient(TEST_PROVIDER_URL, TEST_PRIVATE_KEY)
+    client = TNClient(tn_node, DEFAULT_TN_PRIVATE_KEY)
     return client
 
 @pytest.fixture(scope="module")
@@ -105,6 +102,76 @@ def test_batch_small_batches(client, helper_contract_id, current_account):
     finally:
         client.destroy_stream(stream_id)
 
+def test_batch_small_batches_non_unix(client, helper_contract_id, current_account):
+    """
+    Test inserting 20 small batches of records (5 records each) in a single batch call using non-unix format.
+    """
+    stream_id = generate_stream_id("test_batch_small_non_unix")
+
+    try:
+        client.destroy_stream(stream_id)
+    except Exception:
+        pass
+
+    client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive)
+    client.init_stream(stream_id)
+
+    try:
+        NUM_BATCHES = 500
+        RECORDS_PER_BATCH = 5
+
+        # Time the insertions
+        insert_start = time.time()
+
+        # Prepare all batches
+        batches: List[RecordBatch] = []
+        start_date = datetime(2023, 1, 1)  # Start date
+        for batch in range(NUM_BATCHES):
+            records = []
+            for i in range(RECORDS_PER_BATCH):
+                # Use timedelta to increment the date correctly
+                record_date = start_date + timedelta(days=batch * RECORDS_PER_BATCH + i)
+                records.append(
+                    Record(
+                        date=record_date.strftime("%Y-%m-%d"),  # Format the date
+                        value=float(batch * 100 + i)
+                    )
+                )
+            batches.append(RecordBatch(
+                stream_id=stream_id,
+                inputs=records
+            ))
+
+        # Insert all batches at once
+        tx_hash = client.batch_insert_records(batches, helper_contract_stream_id=helper_contract_id, helper_contract_data_provider=current_account, wait=False)['tx_hash']
+        assert tx_hash
+
+        insert_duration = time.time() - insert_start
+        print(f"[Small Batches Non-Unix] All insertions completed in {insert_duration:.2f}s "
+              f"(avg {(insert_duration/NUM_BATCHES)*1000:.2f}ms per batch, "
+              f"{(insert_duration/(NUM_BATCHES*RECORDS_PER_BATCH))*1000:.2f}ms per record)")
+
+        # Time the confirmations
+        confirm_start = time.time()
+        
+        # Wait for all transactions after sending them all
+        client.wait_for_tx(tx_hash)
+
+        confirm_duration = time.time() - confirm_start
+        print(f"[Small Batches Non-Unix] All transactions confirmed in {confirm_duration:.2f}s")
+
+        # Verify total number of records
+        total_records = NUM_BATCHES * RECORDS_PER_BATCH
+        retrieved_records = client.get_records(
+            stream_id,
+            date_from="2023-01-01",
+            date_to="2028-01-01"  # Fetch a wide range to ensure all records are retrieved.
+        )
+        assert len(retrieved_records) == total_records
+
+    finally:
+        client.destroy_stream(stream_id)
+
 def test_batch_large_batches(client, helper_contract_id, current_account):
     """
     Test inserting 5 large batches of records (100 records each) in a single batch call.
@@ -147,6 +214,51 @@ def test_batch_large_batches(client, helper_contract_id, current_account):
             client.batch_insert_records_unix(batches, helper_contract_stream_id=helper_contract_id, helper_contract_data_provider=current_account, wait=False)
 
         print("[Large Batches] Test passed: Request was correctly rejected as too large")
+
+    finally:
+        client.destroy_stream(stream_id)
+
+def test_batch_large_batches_non_unix(client, helper_contract_id, current_account):
+    """
+    Test inserting 5 large batches of records (100 records each) in a single batch call using non-unix format.
+    This test expects to fail with a "Request too large" error.
+    """
+    stream_id = generate_stream_id("test_batch_large_non_unix")
+    try:
+        client.destroy_stream(stream_id)
+    except Exception:
+        pass
+
+    client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive)
+    client.init_stream(stream_id)
+
+    try:
+        NUM_BATCHES = 500
+        RECORDS_PER_BATCH = 100
+
+        # Time the insertions
+        insert_start = time.time()
+        
+        # Prepare all batches
+        batches: List[RecordBatch] = []
+        for batch in range(NUM_BATCHES):
+            records = [
+                Record(
+                    date=f"2023-01-{(batch % 28) + 1:02d}",  # Cycle through days 1-28
+                    value=float(batch * 1000 + i)
+                )
+                for i in range(RECORDS_PER_BATCH)
+            ]
+            batches.append(RecordBatch(
+                stream_id=stream_id,
+                inputs=records
+            ))
+        
+        # Insert all batches at once - this should fail with a "Request too large" error
+        with pytest.raises(ValueError, match="Request too large: The batch size exceeds the maximum allowed size"):
+            client.batch_insert_records(batches, helper_contract_stream_id=helper_contract_id, helper_contract_data_provider=current_account, wait=False)
+
+        print("[Large Batches Non-Unix] Test passed: Request was correctly rejected as too large")
 
     finally:
         client.destroy_stream(stream_id)
@@ -199,6 +311,62 @@ def test_batch_single_record_inserts(client, helper_contract_id, current_account
             stream_id,
             date_from=base_timestamp,
             date_to=base_timestamp + (NUM_RECORDS * 3600)
+        )
+        assert len(retrieved_records) == NUM_RECORDS
+
+    finally:
+        client.destroy_stream(stream_id)
+
+def test_batch_single_record_inserts_non_unix(client, helper_contract_id, current_account):
+    """
+    Test inserting individual records in a single batch call using non-unix format.
+    """
+    stream_id = generate_stream_id("test_batch_singles_non_unix")
+
+    try:
+        client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive)
+        client.init_stream(stream_id)
+        NUM_RECORDS = 500
+
+        # Time the insertions
+        insert_start = time.time()
+
+        # Prepare all records as individual batches
+        batches: List[RecordBatch] = []
+        start_date = datetime(2023, 1, 1)  # Start date
+        for i in range(NUM_RECORDS):
+            # Use timedelta to increment the date
+            record_date = start_date + timedelta(days=i)
+            batches.append(RecordBatch(
+                stream_id=stream_id,
+                inputs=[Record(
+                    date=record_date.strftime("%Y-%m-%d"),  # Format the date
+                    value=float(i)
+                )]
+            ))
+
+        # Insert all records at once
+        tx_hash = client.batch_insert_records(batches, helper_contract_stream_id=helper_contract_id, helper_contract_data_provider=current_account, wait=False)['tx_hash']
+        assert tx_hash
+
+        insert_duration = time.time() - insert_start
+        print(f"[Single Records Non-Unix] All insertions completed in {insert_duration:.2f}s "
+              f"(avg {(insert_duration/NUM_RECORDS)*1000:.2f}ms per record)")
+
+        # Time the confirmations
+        confirm_start = time.time()
+        
+        # Wait for all transactions after sending them all
+        client.wait_for_tx(tx_hash)
+
+        confirm_duration = time.time() - confirm_start
+        print(f"[Single Records Non-Unix] All transactions confirmed in {confirm_duration:.2f}s")
+
+        # Verify all records were inserted
+        retrieved_records = client.get_records(
+            stream_id,
+            date_from="2023-01-01",
+            date_to="2028-01-01" # broad date range
         )
         assert len(retrieved_records) == NUM_RECORDS
 

--- a/tests/test_sequential_inserts.py
+++ b/tests/test_sequential_inserts.py
@@ -165,7 +165,6 @@ def test_batch_small_batches_non_unix(client, helper_contract_id, current_accoun
         retrieved_records = client.get_records(
             stream_id,
             date_from="2023-01-01",
-            date_to="2028-01-01"  # Fetch a wide range to ensure all records are retrieved.
         )
         assert len(retrieved_records) == total_records
 
@@ -365,8 +364,7 @@ def test_batch_single_record_inserts_non_unix(client, helper_contract_id, curren
         # Verify all records were inserted
         retrieved_records = client.get_records(
             stream_id,
-            date_from="2023-01-01",
-            date_to="2028-01-01" # broad date range
+            date_from="2023-01-01"
         )
         assert len(retrieved_records) == NUM_RECORDS
 


### PR DESCRIPTION
# Batch Insert Records Implementation

## Description

This pull request introduces the `BatchInsertRecords` functionality to the TrufNetwork SDK. It efficiently inserts multiple batches of records across different streams in a single transaction.

*   **New Functionality:** Implemented `BatchInsertRecords` in both Go (`bindings/bindings.go`) and Python (`src/trufnetwork_sdk_py/client.py`).
*   **Data Structures:** Added `Batch` and `Record` structs (Go) and `RecordBatch` and `Record` TypedDicts (Python) to represent batches and individual records.
*   **Testing:**
    *   Added comprehensive tests (`tests/test_sequential_inserts.py`) to verify batch insertion with varying batch sizes and record formats (Unix and non-Unix timestamps).
    *   Included tests to ensure proper error handling for oversized batches.
    *   Created pytest fixtures (`tests/fixtures/test_trufnetwork.py`, `tests/conftest.py`) for a robust testing environment with Docker.
* **Dependencies:** Added `pytest-mock` and `requests` as dev dependencies in `pyproject.toml`.

## Related Problem

- fix #12 

## How Has This Been Tested?

*   **Automated Tests:**  Extensive tests were added to `tests/test_sequential_inserts.py` covering:
    *   Small batches (Unix and non-Unix timestamps).
    *   Large batches (Unix and non-Unix timestamps), including tests for expected failure due to size limits.
    *   Single-record batches (Unix and non-Unix timestamps).
*   **Testing Environment:**  A Dockerized testing environment was set up using pytest fixtures (`tests/fixtures/test_trufnetwork.py`, `tests/conftest.py`) to ensure consistent and reproducible results. This includes a Postgres database and a TSN-DB node.
* **Local Execution:** All tests were run locally and passed. 