### PR TITLE
feat: add support for slice arguments in Python bindings

### DIFF
--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -55,6 +55,24 @@ func ArgsFromFloats(values []float64) ProcedureArgs {
 	return anySlice
 }
 
+// using variadic to make it easier to consume from python
+func ArgsFromStringsSlice(values ...[]string) ProcedureArgs {
+	var anySlice []any
+	for _, v := range values {
+		anySlice = append(anySlice, v)
+	}
+	return anySlice
+}
+
+// using variadic to make it easier to consume from python
+func ArgsFromFloatsSlice(values ...[]float64) ProcedureArgs {
+	var anySlice []any
+	for _, v := range values {
+		anySlice = append(anySlice, v)
+	}
+	return anySlice
+}
+
 // NewClient creates a new TN client with the given provider and private key.
 func NewClient(provider string, privateKey string) (*tnclient.Client, error) {
 	ctx := context.Background()

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -435,6 +435,17 @@ class TNClient:
                 variadic_args.append(
                     truf_sdk.ArgsFromFloats(go.Slice_float64(float_list))
                 )
+            # now for array of arrays
+            elif all_is_list_of_strings(arg_list):
+                all_slices = [go.Slice_string(item) for item in arg_list]
+                variadic_args.append(
+                    truf_sdk.ArgsFromStringsSlice(*all_slices)
+                )
+            elif all_is_list_of_floats(arg_list):
+                all_slices = [go.Slice_float64(item) for item in arg_list]
+                variadic_args.append(
+                    truf_sdk.ArgsFromFloatsSlice(*all_slices)
+                )
             else:
                 raise ValueError(f"Unsupported argument types in {arg_list}")
 
@@ -586,3 +597,10 @@ class TNClient:
         except (AttributeError, KeyError, ValueError) as e:
             # If any conversion fails, return None
             return None
+
+def all_is_list_of_strings(arg_list: List[Any]) -> bool:
+    return all(isinstance(item, list) and all(isinstance(item, str) for item in arg_list) for item in arg_list)
+
+def all_is_list_of_floats(arg_list: List[Any]) -> bool:
+    return all(isinstance(item, list) and all(isinstance(item, (float, int)) for item in arg_list) for item in arg_list)
+

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -404,7 +404,7 @@ class TNClient:
         stream_id: str,
         data_provider: str,
         procedure: str,
-        args: List[List[Union[str, float, int]]],
+        args: list[list[Union[str, float, int, list[str], list[float]]]],
         wait: bool = True,
     ) -> str:
         """
@@ -416,7 +416,7 @@ class TNClient:
             - stream_id: str
             - data_provider: str (hex string)
             - procedure: str
-            - args: List[List[Union[str, float, int]]]
+            - args: List[List[Union[str, float, int, list[str], list[float]]]]
             - wait: bool
         """
         # Transpose the 2D args
@@ -598,9 +598,9 @@ class TNClient:
             # If any conversion fails, return None
             return None
 
-def all_is_list_of_strings(arg_list: List[Any]) -> bool:
-    return all(isinstance(item, list) and all(isinstance(item, str) for item in arg_list) for item in arg_list)
+def all_is_list_of_strings(arg_list: list[Any]) -> bool:
+    return all(isinstance(arg, list) and all(isinstance(item, str) for item in arg) for arg in arg_list)
 
-def all_is_list_of_floats(arg_list: List[Any]) -> bool:
-    return all(isinstance(item, list) and all(isinstance(item, (float, int)) for item in arg_list) for item in arg_list)
+def all_is_list_of_floats(arg_list: list[Any]) -> bool:
+    return all(isinstance(arg, list) and all(isinstance(item, (float, int)) for item in arg) for arg in arg_list)
 


### PR DESCRIPTION
- Introduced new variadic functions ArgsFromStringsSlice and ArgsFromFloatsSlice in Go bindings
- Updated Python client to handle list of lists for strings and floats
- Added helper functions all_is_list_of_strings and all_is_list_of_floats to support type checking
- Improved argument conversion for more complex nested list scenarios in TNClient

already tested on usage