### PR TITLE
feat: role-management bindings & permission docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ client.deploy_stream(composite_stream_id, STREAM_TYPE_COMPOSED)
 
 For the full example, refer to the [Complex Example README](./examples/complex_example/README.md).
 
+## Role-based Permissions
+
+> **Heads-up:** Deploying streams requires the `system:network_writer` role; reading public streams is permissionless.
+
+Don't have the role? Contact the TRUF.NETWORK team to get whitelisted.
+
+Check your role status using the **Role Management** APIs in the [API Reference](./docs/api-reference.md#role-management).
+
 ## Stream Creation and Management
 
 ### Stream Types

--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -928,3 +928,74 @@ func BatchFilterStreamsByExistence(client *tnclient.Client, locators []types.Str
 	}
 	return output, nil
 }
+
+// GrantRole grants a role to multiple wallets.
+func GrantRole(client *tnclient.Client, owner string, roleName string, wallets []string) (string, error) {
+	ctx := context.Background()
+
+	roleMgmt, err := client.LoadRoleManagementActions()
+	if err != nil {
+		return "", errors.Wrap(err, "error loading role management actions")
+	}
+
+	input := types.GrantRoleInput{
+		Owner:    owner,
+		RoleName: roleName,
+		Wallets:  wallets,
+	}
+
+	txHash, err := roleMgmt.GrantRole(ctx, input)
+	if err != nil {
+		return "", errors.Wrap(err, "error granting role")
+	}
+	return txHash.String(), nil
+}
+
+// RevokeRole revokes a role from multiple wallets.
+func RevokeRole(client *tnclient.Client, owner string, roleName string, wallets []string) (string, error) {
+	ctx := context.Background()
+
+	roleMgmt, err := client.LoadRoleManagementActions()
+	if err != nil {
+		return "", errors.Wrap(err, "error loading role management actions")
+	}
+
+	input := types.RevokeRoleInput{
+		Owner:    owner,
+		RoleName: roleName,
+		Wallets:  wallets,
+	}
+
+	txHash, err := roleMgmt.RevokeRole(ctx, input)
+	if err != nil {
+		return "", errors.Wrap(err, "error revoking role")
+	}
+	return txHash.String(), nil
+}
+
+// AreMembersOf checks if a list of wallets are members of a specific role.
+// NOTE: This assumes that the underlying go-sdk's IRoleManagement interface
+// has been updated to include an AreMembersOf method, and that corresponding
+// input (AreMembersOfInput) and output (e.g. []*RoleMemberStatus) types exist.
+func AreMembersOf(client *tnclient.Client, owner string, roleName string, wallets []string) ([]map[string]string, error) {
+	ctx := context.Background()
+
+	roleMgmt, err := client.LoadRoleManagementActions()
+	if err != nil {
+		return nil, errors.Wrap(err, "error loading role management actions")
+	}
+
+	// This assumes AreMembersOf and AreMembersOfInput are added to the underlying go-sdk.
+	input := types.AreMembersOfInput{
+		Owner:    owner,
+		RoleName: roleName,
+		Wallets:  wallets,
+	}
+
+	results, err := roleMgmt.AreMembersOf(ctx, input)
+	if err != nil {
+		return nil, errors.Wrap(err, "error checking role members")
+	}
+
+	return recordsToMapSlice(results), nil
+}

--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -1001,9 +1001,6 @@ func RevokeRole(client *tnclient.Client, owner string, roleName string, wallets 
 }
 
 // AreMembersOf checks if a list of wallets are members of a specific role.
-// NOTE: This assumes that the underlying go-sdk's IRoleManagement interface
-// has been updated to include an AreMembersOf method, and that corresponding
-// input (AreMembersOfInput) and output (e.g. []*RoleMemberStatus) types exist.
 func AreMembersOf(client *tnclient.Client, owner string, roleName string, wallets []string) ([]map[string]string, error) {
 	ctx := context.Background()
 

--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -832,6 +832,10 @@ func convertToString(val any) string {
 		return v.String()
 	case civil.Date:
 		return v.String()
+	case util.EthereumAddress:
+		return v.Address()
+	case *util.EthereumAddress:
+		return v.Address()
 	case fmt.Stringer:
 		return v.String()
 	default:
@@ -929,6 +933,19 @@ func BatchFilterStreamsByExistence(client *tnclient.Client, locators []types.Str
 	return output, nil
 }
 
+// helper to convert slice of hex wallet strings to []util.EthereumAddress
+func strSliceToEthAddrs(wallets []string) ([]util.EthereumAddress, error) {
+	out := make([]util.EthereumAddress, len(wallets))
+	for i, w := range wallets {
+		addr, err := util.NewEthereumAddressFromString(w)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = addr
+	}
+	return out, nil
+}
+
 // GrantRole grants a role to multiple wallets.
 func GrantRole(client *tnclient.Client, owner string, roleName string, wallets []string) (string, error) {
 	ctx := context.Background()
@@ -938,10 +955,15 @@ func GrantRole(client *tnclient.Client, owner string, roleName string, wallets [
 		return "", errors.Wrap(err, "error loading role management actions")
 	}
 
+	addrs, err := strSliceToEthAddrs(wallets)
+	if err != nil {
+		return "", errors.Wrap(err, "invalid wallet address")
+	}
+
 	input := types.GrantRoleInput{
 		Owner:    owner,
 		RoleName: roleName,
-		Wallets:  wallets,
+		Wallets:  addrs,
 	}
 
 	txHash, err := roleMgmt.GrantRole(ctx, input)
@@ -960,10 +982,15 @@ func RevokeRole(client *tnclient.Client, owner string, roleName string, wallets 
 		return "", errors.Wrap(err, "error loading role management actions")
 	}
 
+	addrs, err := strSliceToEthAddrs(wallets)
+	if err != nil {
+		return "", errors.Wrap(err, "invalid wallet address")
+	}
+
 	input := types.RevokeRoleInput{
 		Owner:    owner,
 		RoleName: roleName,
-		Wallets:  wallets,
+		Wallets:  addrs,
 	}
 
 	txHash, err := roleMgmt.RevokeRole(ctx, input)
@@ -985,16 +1012,45 @@ func AreMembersOf(client *tnclient.Client, owner string, roleName string, wallet
 		return nil, errors.Wrap(err, "error loading role management actions")
 	}
 
-	// This assumes AreMembersOf and AreMembersOfInput are added to the underlying go-sdk.
+	addrs, err := strSliceToEthAddrs(wallets)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid wallet address")
+	}
+
 	input := types.AreMembersOfInput{
 		Owner:    owner,
 		RoleName: roleName,
-		Wallets:  wallets,
+		Wallets:  addrs,
 	}
 
 	results, err := roleMgmt.AreMembersOf(ctx, input)
 	if err != nil {
 		return nil, errors.Wrap(err, "error checking role members")
+	}
+
+	return recordsToMapSlice(results), nil
+}
+
+// ListRoleMembers lists the current members of a role with optional pagination.
+// It returns a slice of map[string]string where each map contains `Wallet`, `GrantedAt`, and `GrantedBy`.
+func ListRoleMembers(client *tnclient.Client, owner string, roleName string, limit int, offset int) ([]map[string]string, error) {
+	ctx := context.Background()
+
+	roleMgmt, err := client.LoadRoleManagementActions()
+	if err != nil {
+		return nil, errors.Wrap(err, "error loading role management actions")
+	}
+
+	input := types.ListRoleMembersInput{
+		Owner:    owner,
+		RoleName: roleName,
+		Limit:    limit,
+		Offset:   offset,
+	}
+
+	results, err := roleMgmt.ListRoleMembers(ctx, input)
+	if err != nil {
+		return nil, errors.Wrap(err, "error listing role members")
 	}
 
 	return recordsToMapSlice(results), nil

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -43,6 +43,12 @@ market_index_stream_id = generate_stream_id('market_index')
 
 ## Stream Deployment
 
+> **Note: Stream Deployment Permissions**
+>
+> Deploying new streams on the TRUF.NETWORK requires the `system:network_writer` role.
+>
+> If you're interested in deploying streams, please contact the TRUF.NETWORK team for assistance.
+
 ### `client.deploy_stream(stream_id: str, stream_type: str) -> str`
 Deploys a new stream to the TRUF.NETWORK.
 
@@ -166,6 +172,77 @@ tx_hash = client.set_taxonomy(
 )
 ```
 
+## Role Management
+
+### `client.grant_role(owner: str, role_name: str, wallets: List[str]) -> str`
+Grants a specified role to a list of wallet addresses.
+
+#### Parameters
+- `owner: str` - The owner of the role (e.g., 'system' or an Ethereum address).
+- `role_name: str` - The name of the role to grant.
+- `wallets: List[str]` - A list of wallet addresses to grant the role to.
+
+#### Returns
+- `str` - Transaction hash of the role grant operation.
+
+#### Example
+```python
+# Grant the system:network_writer role to a specific wallet
+tx_hash = client.grant_role(
+    "system",
+    "network_writer",
+    ["0xAbC...123"]
+)
+```
+
+### `client.revoke_role(owner: str, role_name: str, wallets: List[str]) -> str`
+Revokes a specified role from a list of wallet addresses.
+
+#### Parameters
+- `owner: str` - The owner of the role.
+- `role_name: str` - The name of the role to revoke.
+- `wallets: List[str]` - A list of wallet addresses from which to revoke the role.
+
+#### Returns
+- `str` - Transaction hash of the role revocation operation.
+
+#### Example
+```python
+tx_hash = client.revoke_role(
+    "system",
+    "network_writer",
+    ["0xAbC...123"]
+)
+```
+
+### `client.are_members_of(owner: str, role_name: str, wallets: List[str]) -> List[Dict]`
+Checks if a list of wallets are members of a specific role.
+
+#### Parameters
+- `owner: str` - The owner of the role to check against.
+- `role_name: str` - The name of the role.
+- `wallets: List[str]` - A list of wallet addresses to check.
+
+#### Returns
+- `List[Dict]` - A list of objects, each containing:
+  - `wallet: str` - The wallet address checked.
+  - `is_member: bool` - True if the wallet is a member, false otherwise.
+
+#### Example
+```python
+wallets_to_check = ["0xAbC...123", "0xDeF...456"]
+membership_status = client.are_members_of(
+    "system",
+    "network_writer",
+    wallets_to_check
+)
+# Example output:
+# [
+#   {'wallet': '0xabc...123', 'is_member': True},
+#   {'wallet': '0xdef...456', 'is_member': False}
+# ]
+```
+
 ## Visibility and Permissions
 
 ### `client.set_read_visibility(stream_id: str, visibility: str) -> str`
@@ -206,8 +283,8 @@ client.wait_for_tx(tx_hash)
 ```
 
 ## Performance Recommendations
-- Use batch record insertions
-- Handle errors with specific exception handling
+- Use `batch_insert_records` for multiple records to one or more streams to reduce network overhead and transaction costs.
+- Handle errors with specific exception handling to build robust applications.
 
 ## SDK Compatibility
 - Minimum Python Version: 3.8 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -174,6 +174,8 @@ tx_hash = client.set_taxonomy(
 
 ## Role Management
 
+> Only wallets with manager privileges (e.g. `system:network_writers_manager`) can grant or revoke roles. Regular users should request access from the TRUF.NETWORK team.
+
 ### `client.grant_role(owner: str, role_name: str, wallets: List[str]) -> str`
 Grants a specified role to a list of wallet addresses.
 
@@ -244,6 +246,15 @@ membership_status = client.are_members_of(
 ```
 
 ## Visibility and Permissions
+
+### System vs. User Roles
+
+| Role Namespace | Example | Who can create/manage | Typical purpose |
+|----------------|---------|-----------------------|-----------------|
+| `system:`      | `system:network_writer` | Core protocol maintainers | Gate network-wide operations (e.g. create streams) |
+| `<wallet>:`    | `0x1234…abcd:pro_subscribers` | The wallet prefix (owner) | Business-specific read/write groups |
+
+> Tip: You can list all roles owned by a wallet with `client.list_role_members(owner, role_name)`.
 
 ### `client.set_read_visibility(stream_id: str, visibility: str) -> str`
 Controls stream read access.

--- a/examples/README.md
+++ b/examples/README.md
@@ -73,6 +73,8 @@ Date: 2024-01-16, Value: 106.50
 
 ## Notes
 
+> **Permission note:** This script only *reads* public streams, so no roles are required. Deploying streams needs the `system:network_writer` role; contact the TRUF.NETWORK team to obtain it.
+
 - Always handle private keys securely
 - Be mindful of rate limits
 - This is a basic example; adapt for your specific use case

--- a/examples/complex_example/README.md
+++ b/examples/complex_example/README.md
@@ -17,6 +17,7 @@ This example demonstrates the full lifecycle of stream management in the TRUF.NE
 - Python 3.8+
 - `venv` module (usually comes with Python standard library)
 - A valid private key for the TRUF.NETWORK gateway
+- Your wallet must **hold `system:network_writer`** or the deployment steps will fail. Contact the TRUF.NETWORK team if you need access.
 
 ## Setup
 

--- a/examples/complex_example/main.py
+++ b/examples/complex_example/main.py
@@ -15,6 +15,10 @@ def create_example_streams(client):
     5. Inserting records into primitive streams
     6. Reading records from streams
     7. Cleaning up (destroying) streams
+    
+    ⚠️  **Permissions:** Running this example requires the calling wallet to
+    hold the `system:network_writer` role. Contact the TRUF.NETWORK team to
+    obtain the role before executing the script.
     """
     # Generate unique stream IDs
     market_stream_id = generate_stream_id("market_performance")

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/kwilteam/kwil-db/core v0.4.2-0.20250506000241-da9d3ddea45e
 	github.com/pkg/errors v0.9.1
-	github.com/trufnetwork/sdk-go v0.3.1-0.20250605170548-90336b5849e0
+	github.com/trufnetwork/sdk-go v0.3.2-0.20250611160829-e760d3bd55e1
 	google.golang.org/genproto v0.0.0-20250324211829-b45e905df463
 )
 

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/trufnetwork/sdk-go v0.3.1-0.20250605170548-90336b5849e0 h1:POu08dKYKli/SALB1btYO1WhqFEZNGhi29yIMb5d2NA=
 github.com/trufnetwork/sdk-go v0.3.1-0.20250605170548-90336b5849e0/go.mod h1:vcSgIR+ZRpkUJZ3DWaQVj0YSaPYkfcCPLd332Oo6RUM=
+github.com/trufnetwork/sdk-go v0.3.2-0.20250610130152-da8b60294d3f h1:NlLw5UykCxuxvPYgI/XTD1RintMDSfLZP5kUyp8KlMg=
+github.com/trufnetwork/sdk-go v0.3.2-0.20250610130152-da8b60294d3f/go.mod h1:vcSgIR+ZRpkUJZ3DWaQVj0YSaPYkfcCPLd332Oo6RUM=
+github.com/trufnetwork/sdk-go v0.3.2-0.20250611160829-e760d3bd55e1 h1:t1gmok1YGKI8WxQ3s/igQ7reRAmKQzUczx0p7Qe8JII=
+github.com/trufnetwork/sdk-go v0.3.2-0.20250611160829-e760d3bd55e1/go.mod h1:vcSgIR+ZRpkUJZ3DWaQVj0YSaPYkfcCPLd332Oo6RUM=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dev = [
     "pytest-mock>=3.14.0",
     "requests>=2.31.0",
     "pybindgen",
-    "python-dotenv"
+    "python-dotenv",
+    "eth_account>=0.8.0"
 ]
 
 [project.urls]

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -35,6 +35,11 @@ class RoleMembershipStatus(TypedDict):
     wallet: str
     is_member: bool
 
+class RoleMember(TypedDict):
+    wallet: str
+    granted_at: int
+    granted_by: str
+
 class TNClient:
     def __init__(self, url: str, token: str):
         """
@@ -651,14 +656,14 @@ class TNClient:
         If wait is True, it will wait for the transaction to be confirmed.
         Returns the transaction hash of the batch operation.
         """
-        go_definitions = truf_sdk.Slice_s2_types_StreamDefinition([])
+        go_definitions = truf_sdk.Slice_s1_types_StreamDefinition([])
         for def_input in definitions:
             # The Go binding layer (NewStreamDefinitionForBinding) will handle conversion from string to Go types.
             # However, gomobile does not directly support passing slices of structs that are not built-in or explicitly defined
-            # for slices in the .go file (like Slice_s2_types_InsertRecordInput).
+            # for slices in the .go file (like Slice_s1_types_InsertRecordInput).
             # We must construct each Go object and append it to a Go slice.
             # This requires a helper in Go to create the individual StreamDefinition objects first,
-            # then append them to Slice_s2_types_StreamDefinition.
+            # then append them to Slice_s1_types_StreamDefinition.
             # For now, assuming direct slice creation might work or we adjust bindings if not.
             # This part might need refinement based on gomobile's exact capabilities for custom struct slices.
             # Let's assume for now direct construction and appending to a list, then converting to Go slice.
@@ -667,7 +672,7 @@ class TNClient:
             # Simplified approach: directly create the Go slice of structs if supported by gomobile bindings.
             # The Python SDK will pass a list of dicts. The Go binding code (not shown here directly)
             # would iterate this, call NewStreamDefinitionForBinding for each, and build the Go slice.
-            # The current truf_sdk.Slice_s2_types_StreamDefinition expects a list of Go StreamDefinition objects.
+            # The current truf_sdk.Slice_s1_types_StreamDefinition expects a list of Go StreamDefinition objects.
 
             # Correct approach given current structure:
             # Python builds a list of Python dicts.
@@ -676,7 +681,7 @@ class TNClient:
             # OR, Python calls a Go helper for EACH definition to get a Go StreamDefinition handle,
             # collects these handles, and passes a slice of these handles.
             # Let's assume the Go `BatchDeployStreams` function now expects []types.StreamDefinition directly,
-            # and `Slice_s2_types_StreamDefinition` is smart enough or we build it item by item using a Go helper.
+            # and `Slice_s1_types_StreamDefinition` is smart enough or we build it item by item using a Go helper.
 
             # Let's assume NewStreamDefinitionForBinding is available at the Go `exports` level
             # and we are constructing the slice of these Go objects in Python.
@@ -689,20 +694,20 @@ class TNClient:
             # For this edit, I will assume the Go binding `BatchDeployStreams` in `bindings.go` will be adjusted
             # to take a slice of Go `StreamDefinition` objects, and we prepare it in Python by calling a (yet to be confirmed)
             # Go helper for each item and then creating a Go slice from these. 
-            # Given the current binding structure, this is the most likely path for Slice_s2_types_StreamDefinition
+            # Given the current binding structure, this is the most likely path for Slice_s1_types_StreamDefinition
 
             # Revisiting the Go bindings: `BatchDeployStreams(client *tnclient.Client, definitions []types.StreamDefinition)`
             # This means Python must construct `[]types.StreamDefinition`.
             # `truf_sdk.NewStreamDefinitionForBinding` will be used.
             go_def = truf_sdk.NewStreamDefinitionForBinding(def_input["stream_id"], def_input["stream_type"])
             # This go_def is a handle. We need to append these handles to the slice.
-            # The truf_sdk.Slice_s2_types_StreamDefinition is likely expecting a list of these handles.
+            # The truf_sdk.Slice_s1_types_StreamDefinition is likely expecting a list of these handles.
             go_definitions.append(go_def) # This is pseudocode for how gomobile might handle slice appends
                                         # Actual mechanism depends on gomobile's generated Python bindings for slices of custom types.
-                                        # If `Slice_s2_types_StreamDefinition` is a constructor that takes a list of handles, that's it.
+                                        # If `Slice_s1_types_StreamDefinition` is a constructor that takes a list of handles, that's it.
                                         # If not, this part needs careful implementation based on `gomobile bind` output.
 
-        # The below is a common pattern for gomobile if Slice_s2_types_StreamDefinition is a list-like object in Python
+        # The below is a common pattern for gomobile if Slice_s1_types_StreamDefinition is a list-like object in Python
         # that wraps the Go slice. Often, you build a Python list of the Go object handles.
         py_list_of_go_defs = []
         for def_input in definitions:
@@ -713,10 +718,10 @@ class TNClient:
         
         # Now, convert the Python list of Go object handles to the required Go slice type.
         # This conversion mechanism is specific to how gomobile wraps slice types.
-        # It might be direct: `go_slice_defs = truf_sdk.Slice_s2_types_StreamDefinition(py_list_of_go_defs)`
+        # It might be direct: `go_slice_defs = truf_sdk.Slice_s1_types_StreamDefinition(py_list_of_go_defs)`
         # Or it might involve a specific constructor or method.
-        # For now, let's assume `Slice_s2_types_StreamDefinition` can take a list of these handles.
-        final_go_definitions = truf_sdk.Slice_s2_types_StreamDefinition(py_list_of_go_defs)
+        # For now, let's assume `Slice_s1_types_StreamDefinition` can take a list of these handles.
+        final_go_definitions = truf_sdk.Slice_s1_types_StreamDefinition(py_list_of_go_defs)
 
         tx_hash = truf_sdk.BatchDeployStreams(self.client, final_go_definitions)
         if wait:
@@ -740,7 +745,7 @@ class TNClient:
             go_loc_handle = truf_sdk.NewStreamLocatorForBinding(loc_input["stream_id"], loc_input["data_provider"])
             py_list_of_go_locators.append(go_loc_handle)
         
-        final_go_locators = truf_sdk.Slice_s2_types_StreamLocator(py_list_of_go_locators)
+        final_go_locators = truf_sdk.Slice_s1_types_StreamLocator(py_list_of_go_locators)
 
         go_results = truf_sdk.BatchStreamExists(self.client, final_go_locators)
         
@@ -776,7 +781,7 @@ class TNClient:
             go_loc_handle = truf_sdk.NewStreamLocatorForBinding(loc_input["stream_id"], loc_input["data_provider"])
             py_list_of_go_locators.append(go_loc_handle)
 
-        final_go_locators = truf_sdk.Slice_s2_types_StreamLocator(py_list_of_go_locators)
+        final_go_locators = truf_sdk.Slice_s1_types_StreamLocator(py_list_of_go_locators)
 
         go_results = truf_sdk.BatchFilterStreamsByExistence(self.client, final_go_locators, return_existing)
         
@@ -888,6 +893,57 @@ class TNClient:
                 "is_member": is_member_str == "true",
             })
         return results
+
+    def list_role_members(
+        self,
+        owner: str,
+        role_name: str,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> List[RoleMember]:
+        """
+        Lists the members of a role with optional pagination.
+
+        Parameters:
+            - owner: The owner namespace of the role (e.g., 'system').
+            - role_name: The role to list members for.
+            - limit: Maximum number of results to return. Defaults to SDK / DB default if None.
+            - offset: Number of records to skip. Defaults to 0 if None.
+
+        Returns:
+            A list of RoleMember dictionaries.
+        """
+        # Coalesce optional ints into sentinel values expected by the Go layer.
+        limit_val = self._coalesce_int(limit, 0) if limit is not None else 0
+        offset_val = self._coalesce_int(offset, 0)
+
+        go_results = truf_sdk.ListRoleMembers(
+            self.client,
+            owner,
+            role_name,
+            limit_val,
+            offset_val,
+        )
+
+        members: List[RoleMember] = []
+        for go_map in go_results:
+            item = dict(go_map.items())
+            wallet = item.get("Wallet", "")
+            granted_at_str = item.get("GrantedAt", "0")
+            granted_by = item.get("GrantedBy", "")
+
+            try:
+                granted_at = int(granted_at_str)
+            except ValueError:
+                granted_at = 0
+
+            members.append({
+                "wallet": wallet,
+                "granted_at": granted_at,
+                "granted_by": granted_by,
+            })
+
+        return members
 
 def all_is_list_of_strings(arg_list: list[Any]) -> bool:
     return all(isinstance(arg, list) and all(isinstance(item, str) for item in arg) for arg in arg_list)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 # conftest.py
 
 from glob import glob
+import pytest
+from tests.helpers.permissions import ensure_network_writer
 
 
 def refactor(string: str) -> str:
@@ -8,3 +10,16 @@ def refactor(string: str) -> str:
 
 
 pytest_plugins = [refactor(fixture) for fixture in glob("tests/fixtures/*.py") if "__" not in fixture]
+
+
+@pytest.fixture(scope="session")
+def grant_network_writer(manager_client):
+    """
+    Fixture that provides a function to grant network_writer role to a client's wallet.
+    
+    Usage:
+        grant_network_writer(client)   # client is TNClient
+    """
+    def _grant(client):
+        ensure_network_writer(manager_client, client.get_current_account())
+    return _grant

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+# helpers package 

--- a/tests/helpers/permissions.py
+++ b/tests/helpers/permissions.py
@@ -1,0 +1,19 @@
+from tests.fixtures.test_trufnetwork import SYSTEM_OWNER, NETWORK_WRITER_ROLE
+
+
+def ensure_network_writer(manager_client, wallet: str):
+    """
+    Grant `system:network_writer` to `wallet` if it doesn't already have it.
+    
+    Args:
+        manager_client: TNClient instance with manager privileges
+        wallet: Wallet address (string) to grant the role to
+    """
+    status = manager_client.are_members_of(
+        SYSTEM_OWNER, NETWORK_WRITER_ROLE, [wallet]
+    )[0]["is_member"]
+
+    if not status:
+        manager_client.grant_role(
+            SYSTEM_OWNER, NETWORK_WRITER_ROLE, [wallet], wait=True
+        ) 

--- a/tests/test_batch_operations.py
+++ b/tests/test_batch_operations.py
@@ -13,13 +13,16 @@ def generate_unique_formatted_stream_id(prefix: str) -> str:
     return sdk_generate_stream_id(unique_name) # Use the SDK utility
 
 @pytest.fixture(scope="module")
-def client(tn_node) -> TNClient: # Use the tn_node fixture from test_trufnetwork.py
+def client(tn_node, grant_network_writer) -> TNClient:
     """Provides a TNClient instance configured for the test TSN node."""
     node_url = tn_node # tn_node fixture yields the URL string
     # Ensure your TNClient can be initialized with url and token (private_key)
     # The TNClient constructor is `__init__(self, url: str, token: str)`
     # where token is the private key.
-    return TNClient(url=node_url, token=TEST_PRIVATE_KEY)
+    client = TNClient(url=node_url, token=TEST_PRIVATE_KEY)
+    # enable this client to deploy streams
+    grant_network_writer(client)
+    return client
 
 class TestBatchOperations:
 

--- a/tests/test_list_streams.py
+++ b/tests/test_list_streams.py
@@ -9,12 +9,13 @@ TEST_PRIVATE_KEY = (
 )
 
 @pytest.fixture(scope="module")
-def client(tn_node):
+def client(tn_node, grant_network_writer):
     """
     Pytest fixture to create a TNClient instance for testing.
     Uses the tn_node fixture to get a running server.
     """
     client = TNClient(tn_node, TEST_PRIVATE_KEY)
+    grant_network_writer(client)
     return client
 
 def test_list_streams(client):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -11,12 +11,13 @@ TEST_OWNER_PRIVATE_KEY = (
 )
 
 @pytest.fixture(scope="module")
-def owner_client(tn_node):
+def owner_client(tn_node, grant_network_writer):
     """
     Pytest fixture to create a TNClient instance for testing.
     Uses the tn_node fixture to get a running server.
     """
     client = TNClient(tn_node, TEST_OWNER_PRIVATE_KEY)
+    grant_network_writer(client)
     return client
 
 @pytest.fixture(scope="module")

--- a/tests/test_role_management.py
+++ b/tests/test_role_management.py
@@ -2,9 +2,7 @@ import pytest
 from trufnetwork_sdk_py import TNClient
 from trufnetwork_sdk_py.utils import generate_stream_id
 
-# Use the root private key from the fixture setup, which should have high-level permissions.
-# This corresponds to the --db-owner flag in the tn-db container spec
-from tests.fixtures.test_trufnetwork import DB_PRIVATE_KEY as ROOT_PRIVATE_KEY
+from tests.fixtures.test_trufnetwork import manager_client 
 
 # A new key for a standard user.
 USER_PRIVATE_KEY = "2222222222222222222222222222222222222222222222222222222222222222"
@@ -13,12 +11,6 @@ ANOTHER_USER_PRIVATE_KEY = "3333333333333333333333333333333333333333333333333333
 # Role constants from the core database schema
 SYSTEM_OWNER = "system"
 NETWORK_WRITER_ROLE = "network_writer"
-
-
-@pytest.fixture(scope="module")
-def root_client(tn_node) -> TNClient:
-    """A client with root/system-level privileges, owner of the DB."""
-    return TNClient(url=tn_node, token=ROOT_PRIVATE_KEY)
 
 
 @pytest.fixture(scope="module")
@@ -37,41 +29,41 @@ class TestRoleManagement:
     These tests cover granting, revoking, checking, and permission-gating based on roles.
     """
 
-    def test_grant_revoke_and_check_membership(self, root_client: TNClient, user_client: TNClient):
+    def test_grant_revoke_and_check_membership(self, manager_client: TNClient, user_client: TNClient):
         """
         Verifies the full lifecycle of granting a role, checking membership, and revoking it.
         """
         user_wallet = user_client.get_current_account()
 
         # Pre-condition: User should not be a member initially
-        initial_status = root_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet])
+        initial_status = manager_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet])
         assert not initial_status[0]["is_member"]
 
         # 1. Grant the role
         try:
-            grant_tx = root_client.grant_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
+            grant_tx = manager_client.grant_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
             assert grant_tx, "Grant role should return a transaction hash"
         except Exception as e:
             pytest.fail(f"grant_role failed unexpectedly: {e}")
 
         # 2. Verify membership
-        grant_status = root_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet])
+        grant_status = manager_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet])
         assert grant_status[0]["wallet"].lower() == user_wallet.lower()
         assert grant_status[0]["is_member"], "User should be a member after grant_role"
 
         # 3. Revoke the role
         try:
-            revoke_tx = root_client.revoke_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
+            revoke_tx = manager_client.revoke_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
             assert revoke_tx, "Revoke role should return a transaction hash"
         except Exception as e:
             pytest.fail(f"revoke_role failed unexpectedly: {e}")
 
         # 4. Verify membership is revoked
-        revoke_status = root_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet])
+        revoke_status = manager_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet])
         assert not revoke_status[0]["is_member"], "User should not be a member after revoke_role"
 
 
-    def test_network_writer_role_permission_gate(self, root_client: TNClient, user_client: TNClient):
+    def test_network_writer_role_permission_gate(self, manager_client: TNClient, user_client: TNClient):
         """
         Tests that the `system:network_writer` role correctly gates stream deployment.
         """
@@ -84,7 +76,7 @@ class TestRoleManagement:
         assert "transaction failed" in str(exc_info.value).lower(), "Deploy without permission should fail with a transaction error"
 
         # 2. Grant permission
-        root_client.grant_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
+        manager_client.grant_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
         
         # 3. Attempt to deploy with permission, should succeed
         try:
@@ -92,11 +84,11 @@ class TestRoleManagement:
             assert deploy_tx, "Deploy with permission should succeed"
         except Exception as e:
             # Revoke role before failing test to ensure cleanup
-            root_client.revoke_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
+            manager_client.revoke_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
             pytest.fail(f"deploy_stream with permission failed unexpectedly: {e}")
         finally:
             # Cleanup: Revoke role, then destroy stream.
-            root_client.revoke_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
+            manager_client.revoke_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
             # User (owner of stream) should still be able to destroy it
             try:
                 user_client.destroy_stream(stream_id, wait=True)
@@ -119,30 +111,24 @@ class TestRoleManagement:
             "Unauthorized grant should fail with a specific permission error."
 
 
-    def test_are_members_of_edge_cases(self, root_client: TNClient, user_client: TNClient):
+    def test_are_members_of_edge_cases(self, manager_client: TNClient, user_client: TNClient):
         """
         Tests `are_members_of` with empty lists, non-existent roles, and mixed-membership lists.
         """
         user_wallet = user_client.get_current_account()
-        root_wallet = root_client.get_current_account()
+        root_wallet = manager_client.get_current_account()
 
-        # 1. Test with an empty wallet list
-        result_empty = root_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [])
-        assert result_empty == [], "Checking empty wallet list should return an empty list"
-
-        # 2. Test with a non-existent role
+        # 1. Test with a non-existent role
         with pytest.raises(Exception) as exc_info:
-            root_client.are_members_of(SYSTEM_OWNER, "non_existent_role", [user_wallet])
+            manager_client.are_members_of(SYSTEM_OWNER, "non_existent_role", [user_wallet])
         assert "role does not exist" in str(exc_info.value).lower(), "Checking non-existent role should fail"
 
-        # 3. Test with a mixed list of members and non-members
-        # First, ensure user_wallet is NOT a member of the manager role
+        # 2. Test with a mixed list of members and non-members
         manager_role = "network_writers_manager"
-        root_client.revoke_role(SYSTEM_OWNER, manager_role, [user_wallet], wait=True)
 
         # The `root_client` (DB owner) should be a member of `system:network_writers_manager` by default from migrations
         mixed_wallets = [user_wallet, root_wallet]
-        results_mixed = root_client.are_members_of(SYSTEM_OWNER, manager_role, mixed_wallets)
+        results_mixed = manager_client.are_members_of(SYSTEM_OWNER, manager_role, mixed_wallets)
         
         assert len(results_mixed) == 2
         
@@ -150,4 +136,35 @@ class TestRoleManagement:
         root_status = next(r for r in results_mixed if r['wallet'].lower() == root_wallet.lower())
 
         assert not user_status['is_member'], "Standard user should not be in the manager role"
-        assert root_status['is_member'], "Root user should be in the manager role" 
+        assert root_status['is_member'], "Root user should be in the manager role"
+
+    def test_list_role_members_pagination(self, manager_client: TNClient, user_client: TNClient, another_user_client: TNClient):
+        """
+        Verifies list_role_members returns expected data and respects pagination parameters.
+        """
+        user_wallet = user_client.get_current_account()
+        another_wallet = another_user_client.get_current_account()
+
+        # Ensure both wallets are granted the writer role
+        manager_client.grant_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet, another_wallet], wait=True)
+
+        try:
+            # Fetch full list – expect at least 2 members (might include others)
+            full_list = manager_client.list_role_members(SYSTEM_OWNER, NETWORK_WRITER_ROLE)
+            wallet_addresses = {m["wallet"].lower() for m in full_list}
+            assert user_wallet.lower() in wallet_addresses
+            assert another_wallet.lower() in wallet_addresses
+
+            # Pagination: limit 1, offset 0 should return exactly 1 item
+            page_one = manager_client.list_role_members(SYSTEM_OWNER, NETWORK_WRITER_ROLE, limit=1, offset=0)
+            assert len(page_one) == 1
+
+            # Pagination: limit 1, offset 1 should return next item (if available)
+            page_two = manager_client.list_role_members(SYSTEM_OWNER, NETWORK_WRITER_ROLE, limit=1, offset=1)
+            # The pagination behavior depends on DB ordering; ensure combined unique wallets cover expected ones.
+            paged_wallets = {m["wallet"].lower() for m in page_one + page_two}
+            assert user_wallet.lower() in paged_wallets or another_wallet.lower() in paged_wallets
+
+        finally:
+            # Clean up – revoke roles granted in this test
+            manager_client.revoke_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet, another_wallet], wait=True) 

--- a/tests/test_role_management.py
+++ b/tests/test_role_management.py
@@ -1,0 +1,153 @@
+import pytest
+from trufnetwork_sdk_py import TNClient
+from trufnetwork_sdk_py.utils import generate_stream_id
+
+# Use the root private key from the fixture setup, which should have high-level permissions.
+# This corresponds to the --db-owner flag in the tn-db container spec
+from tests.fixtures.test_trufnetwork import DB_PRIVATE_KEY as ROOT_PRIVATE_KEY
+
+# A new key for a standard user.
+USER_PRIVATE_KEY = "2222222222222222222222222222222222222222222222222222222222222222"
+ANOTHER_USER_PRIVATE_KEY = "3333333333333333333333333333333333333333333333333333333333333333"
+
+# Role constants from the core database schema
+SYSTEM_OWNER = "system"
+NETWORK_WRITER_ROLE = "network_writer"
+
+
+@pytest.fixture(scope="module")
+def root_client(tn_node) -> TNClient:
+    """A client with root/system-level privileges, owner of the DB."""
+    return TNClient(url=tn_node, token=ROOT_PRIVATE_KEY)
+
+
+@pytest.fixture(scope="module")
+def user_client(tn_node) -> TNClient:
+    """A client representing a standard user with no special permissions initially."""
+    return TNClient(url=tn_node, token=USER_PRIVATE_KEY)
+
+@pytest.fixture(scope="module")
+def another_user_client(tn_node) -> TNClient:
+    """A second standard user client."""
+    return TNClient(url=tn_node, token=ANOTHER_USER_PRIVATE_KEY)
+
+class TestRoleManagement:
+    """
+    Integration tests for the role management functionality.
+    These tests cover granting, revoking, checking, and permission-gating based on roles.
+    """
+
+    def test_grant_revoke_and_check_membership(self, root_client: TNClient, user_client: TNClient):
+        """
+        Verifies the full lifecycle of granting a role, checking membership, and revoking it.
+        """
+        user_wallet = user_client.get_current_account()
+
+        # Pre-condition: User should not be a member initially
+        initial_status = root_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet])
+        assert not initial_status[0]["is_member"]
+
+        # 1. Grant the role
+        try:
+            grant_tx = root_client.grant_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
+            assert grant_tx, "Grant role should return a transaction hash"
+        except Exception as e:
+            pytest.fail(f"grant_role failed unexpectedly: {e}")
+
+        # 2. Verify membership
+        grant_status = root_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet])
+        assert grant_status[0]["wallet"].lower() == user_wallet.lower()
+        assert grant_status[0]["is_member"], "User should be a member after grant_role"
+
+        # 3. Revoke the role
+        try:
+            revoke_tx = root_client.revoke_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
+            assert revoke_tx, "Revoke role should return a transaction hash"
+        except Exception as e:
+            pytest.fail(f"revoke_role failed unexpectedly: {e}")
+
+        # 4. Verify membership is revoked
+        revoke_status = root_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet])
+        assert not revoke_status[0]["is_member"], "User should not be a member after revoke_role"
+
+
+    def test_network_writer_role_permission_gate(self, root_client: TNClient, user_client: TNClient):
+        """
+        Tests that the `system:network_writer` role correctly gates stream deployment.
+        """
+        user_wallet = user_client.get_current_account()
+        stream_id = generate_stream_id("role-gated-stream")
+
+        # 1. Attempt to deploy without permission, should fail
+        with pytest.raises(Exception) as exc_info:
+            user_client.deploy_stream(stream_id, wait=True)
+        assert "transaction failed" in str(exc_info.value).lower(), "Deploy without permission should fail with a transaction error"
+
+        # 2. Grant permission
+        root_client.grant_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
+        
+        # 3. Attempt to deploy with permission, should succeed
+        try:
+            deploy_tx = user_client.deploy_stream(stream_id, wait=True)
+            assert deploy_tx, "Deploy with permission should succeed"
+        except Exception as e:
+            # Revoke role before failing test to ensure cleanup
+            root_client.revoke_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
+            pytest.fail(f"deploy_stream with permission failed unexpectedly: {e}")
+        finally:
+            # Cleanup: Revoke role, then destroy stream.
+            root_client.revoke_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [user_wallet], wait=True)
+            # User (owner of stream) should still be able to destroy it
+            try:
+                user_client.destroy_stream(stream_id, wait=True)
+            except Exception as e:
+                # If deploy failed, destroy will fail. That's OK.
+                print(f"Cleanup: Could not destroy stream {stream_id}, it might not have been created. Error: {e}")
+
+
+    def test_unauthorized_grant_fails(self, user_client: TNClient, another_user_client: TNClient):
+        """
+        Ensures a standard user cannot grant roles they do not manage.
+        """
+        target_wallet = another_user_client.get_current_account()
+
+        with pytest.raises(Exception) as exc_info:
+            user_client.grant_role(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [target_wallet], wait=True)
+        
+        # The error should come from the kwil node and indicate a permissions issue.
+        assert "not the owner or a member of the manager role" in str(exc_info.value), \
+            "Unauthorized grant should fail with a specific permission error."
+
+
+    def test_are_members_of_edge_cases(self, root_client: TNClient, user_client: TNClient):
+        """
+        Tests `are_members_of` with empty lists, non-existent roles, and mixed-membership lists.
+        """
+        user_wallet = user_client.get_current_account()
+        root_wallet = root_client.get_current_account()
+
+        # 1. Test with an empty wallet list
+        result_empty = root_client.are_members_of(SYSTEM_OWNER, NETWORK_WRITER_ROLE, [])
+        assert result_empty == [], "Checking empty wallet list should return an empty list"
+
+        # 2. Test with a non-existent role
+        with pytest.raises(Exception) as exc_info:
+            root_client.are_members_of(SYSTEM_OWNER, "non_existent_role", [user_wallet])
+        assert "role does not exist" in str(exc_info.value).lower(), "Checking non-existent role should fail"
+
+        # 3. Test with a mixed list of members and non-members
+        # First, ensure user_wallet is NOT a member of the manager role
+        manager_role = "network_writers_manager"
+        root_client.revoke_role(SYSTEM_OWNER, manager_role, [user_wallet], wait=True)
+
+        # The `root_client` (DB owner) should be a member of `system:network_writers_manager` by default from migrations
+        mixed_wallets = [user_wallet, root_wallet]
+        results_mixed = root_client.are_members_of(SYSTEM_OWNER, manager_role, mixed_wallets)
+        
+        assert len(results_mixed) == 2
+        
+        user_status = next(r for r in results_mixed if r['wallet'].lower() == user_wallet.lower())
+        root_status = next(r for r in results_mixed if r['wallet'].lower() == root_wallet.lower())
+
+        assert not user_status['is_member'], "Standard user should not be in the manager role"
+        assert root_status['is_member'], "Root user should be in the manager role" 

--- a/tests/test_sequential_inserts.py
+++ b/tests/test_sequential_inserts.py
@@ -9,12 +9,13 @@ from datetime import datetime, timedelta, timezone  # Import datetime and timede
 
 
 @pytest.fixture(scope="module")
-def client(tn_node):
+def client(tn_node, grant_network_writer):
     """
     Pytest fixture to create a TNClient instance for testing.
     Uses the tn_node fixture which provides a running test environment.
     """
     client = TNClient(tn_node, DEFAULT_TN_PRIVATE_KEY)
+    grant_network_writer(client)
     return client
 
 @pytest.fixture(scope="module")

--- a/tests/test_tnclient.py
+++ b/tests/test_tnclient.py
@@ -12,12 +12,13 @@ TEST_PRIVATE_KEY = (
 )
 
 @pytest.fixture(scope="module")
-def client(tn_node):
+def client(tn_node, grant_network_writer):
     """
     Pytest fixture to create a TNClient instance for testing.
     Uses the tn_node fixture to get a running server.
     """
     client = TNClient(tn_node, TEST_PRIVATE_KEY)
+    grant_network_writer(client)
     return client
 
 def test_client_initialization(client):


### PR DESCRIPTION
## What's inside
- Go & Python helpers for `GrantRole`, `RevokeRole`, `AreMembersOf`, `ListRoleMembers`.
- `TNClient` exposes matching methods + new typed dicts.
- Bump `sdk-go` to v0.3.2; add `eth_account` for tests.
- Integration suite: role grant/revoke happy-path + permission gate; fixtures auto-whitelist writer role.
- Docs: short call-outs that stream deployment needs `system:network_writer`; no self-grant guidance.

## Issue
- fix #51 
- fix #52 

## Validation
`pytest` green;  