### PR TITLE
chore: add boolean conversion to string in bindings

### DIFF
--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -836,6 +836,8 @@ func convertToString(val any) string {
 		return v.Address()
 	case *util.EthereumAddress:
 		return v.Address()
+	case bool:
+		return strconv.FormatBool(v)
 	case fmt.Stringer:
 		return v.String()
 	default:


### PR DESCRIPTION
- Enhanced the `convertToString` function to handle boolean values by adding a case that converts `bool` to its string representation using `strconv.FormatBool`.

---

- fix #60 