### PR TITLE
chore: use pre-built Docker images from GHCR for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y patchelf
+
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
@@ -50,11 +55,6 @@ jobs:
         working-directory: tmp-node
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Build tn-db Docker image & kwil-cli binary
-        run: |
-          cd tmp-node
-          task docker:build:local
-
       - name: Cache kwil-cli build
         id: cache-kwil-build
         uses: actions/cache@v4
@@ -67,15 +67,17 @@ jobs:
         run: |
           cd tmp-node
           task build
-      
+
       - name: Copy kwil-cli binary to path
         run: |
           sudo cp tmp-node/.build/kwil-cli /usr/local/bin/kwil-cli
           # smoke test
           kwil-cli version
 
-      - name: Pull postgres image
-        run: docker pull kwildb/postgres:16.8-1
+      - name: Pull Docker images
+        run: |
+          docker pull ghcr.io/trufnetwork/node:latest
+          docker pull kwildb/postgres:latest
 
       - name: Install dependencies
         run: |

--- a/tests/fixtures/test_trufnetwork.py
+++ b/tests/fixtures/test_trufnetwork.py
@@ -56,7 +56,7 @@ class ContainerSpec:
 # Container specifications
 POSTGRES_CONTAINER = ContainerSpec(
     name="test-kwil-postgres",
-    image="kwildb/postgres:latest",
+    image=os.environ.get("POSTGRES_IMAGE", "kwildb/postgres:latest"),
     tmpfs_path="/var/lib/postgresql/data",
     env_vars=["POSTGRES_HOST_AUTH_METHOD=trust"],
     ports={"5432": "5432"}
@@ -64,7 +64,7 @@ POSTGRES_CONTAINER = ContainerSpec(
 
 TN_DB_CONTAINER = ContainerSpec(
     name="test-tn-db",
-    image="tn-db:local",
+    image=os.environ.get("TN_DB_IMAGE", "ghcr.io/trufnetwork/node:latest"),
     tmpfs_path="/root/.kwild",
     entrypoint="/app/kwild",
     args=[


### PR DESCRIPTION
compliment for our ghcr releases, so we don't broke it every single time

resolves: https://github.com/trufnetwork/sdk-py/issues/86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline updated to install required system dependencies, stop building one Docker image locally, and pull two pre-built images instead — speeding and simplifying builds.
  * Test setup made configurable to allow Docker image sources to be supplied via environment variables, enabling more flexible testing and deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->