### PR TITLE
feat: insert records in bulk via cached nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,63 @@ for record in records:
     print(f"Date: {date.strftime('%Y-%m-%d')}, Value: {record['Value']}")
 ```
 
+### High-Throughput Insertion with `BulkInserter`
+
+When inserting more than a few hundred records from a single signer, looping
+`client.batch_insert_records(...)` is dramatically slower than it needs to be:
+each call forces a wait-for-inclusion (~1–2s per block) before the next
+broadcast, so 1,000 records can take 25+ minutes.
+
+`BulkInserter` instead caches the nonce locally and broadcasts each chunk
+fire-and-forget, draining inflight transactions in batches via `WaitTx`. It
+handles `invalid nonce` (resets cache, retries) and `mempool full` (backs off,
+keeps cache) automatically.
+
+```python
+from trufnetwork_sdk_py import TNClient, BulkInserter, BulkInsertError
+
+client = TNClient("https://gateway.testnet.truf.network", "YOUR_PRIVATE_KEY")
+inserter = BulkInserter(client)
+
+batches = [
+    {
+        "stream_id": "st...",
+        "inputs": [
+            {"date": 1700000000, "value": 1.5},
+            # ... thousands more
+        ],
+    },
+]
+
+try:
+    tx_hashes = inserter.insert_all(batches)
+    print(f"broadcast {len(tx_hashes)} transactions")
+except BulkInsertError as e:
+    # Error message format: "bulk insert failed at chunk N: <reason>" or
+    # "bulk insert drain failed after N chunks broadcast: <reason>"
+    print(f"bulk insert failed: {e}")
+```
+
+**Constraints:**
+
+- One `BulkInserter` per signer key — concurrent inserters from the same
+  signer collide on nonces (the mempool admits transactions in strict nonce
+  order).
+- Different signers run safely in parallel (independent nonce sequences).
+- Records may mix stream IDs within a chunk — the inserter flattens batches
+  and chunks by total record count.
+
+**Tunables** (defaults shown):
+
+```python
+BulkInserter(
+    client,
+    batch_size=10,      # records per insert_records tx; protocol cap is 10
+    max_inflight=200,   # broadcasts queued before forced drain via WaitTx
+    max_attempts=5,     # initial + retries on transient errors
+)
+```
+
 ## Understanding Transaction Lifecycle
 
 **IMPORTANT:** All transaction operations return success when transactions enter the mempool, NOT when they are executed on-chain. This async behavior can cause race conditions if not handled properly.

--- a/README.md
+++ b/README.md
@@ -149,9 +149,10 @@ try:
     tx_hashes = inserter.insert_all(batches)
     print(f"broadcast {len(tx_hashes)} transactions")
 except BulkInsertError as e:
-    # Error message format: "bulk insert failed at chunk N: <reason>" or
-    # "bulk insert drain failed after N chunks broadcast: <reason>"
-    print(f"bulk insert failed: {e}")
+    # e.tx_hashes — list of hashes broadcast before failure
+    # e.failed_chunk_index — chunk that failed (or total chunks if drain_failure)
+    # e.drain_failure — True if WaitTx failed after all broadcasts succeeded
+    print(f"bulk insert failed: {e}; recovered {len(e.tx_hashes)} partial hashes")
 ```
 
 **Constraints:**

--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -212,6 +212,49 @@ func InsertRecords(client *tnclient.Client, inputs []types.InsertRecordInput) (s
 	return txHash.String(), nil
 }
 
+// NewBulkInserter constructs a BulkInserter wired to the given TNClient.
+// Wraps tnclient.Client.LoadBulkInserter for gopy export to Python.
+//
+// batchSize: records per insert_records tx (must be <= protocol cap of 10).
+// maxInflight: how many broadcasts may queue before draining via WaitTx.
+// maxAttempts: max attempts per chunk (initial + retries) on transient
+// errors (invalid nonce, mempool full).
+// Pass 0 for any of these to use defaults (10, 200, 5).
+func NewBulkInserter(client *tnclient.Client, batchSize int, maxInflight int, maxAttempts int) (*contractsapi.BulkInserter, error) {
+	if client == nil {
+		return nil, fmt.Errorf("client is required")
+	}
+	var opts []contractsapi.BulkInserterOption
+	if batchSize > 0 {
+		opts = append(opts, contractsapi.WithBatchSize(batchSize))
+	}
+	if maxInflight > 0 {
+		opts = append(opts, contractsapi.WithMaxInflight(maxInflight))
+	}
+	if maxAttempts > 0 {
+		opts = append(opts, contractsapi.WithMaxAttempts(maxAttempts))
+	}
+	return client.LoadBulkInserter(opts...)
+}
+
+// BulkInsertAll runs InsertAll against the given inserter and returns the
+// resulting tx hashes as hex strings (for Python consumption).
+//
+// On failure, returns the partial hashes plus an error. Callers can extract
+// the failing chunk index by checking the error message format
+// "bulk insert failed at chunk N: ...".
+func BulkInsertAll(b *contractsapi.BulkInserter, inputs []types.InsertRecordInput) ([]string, error) {
+	if b == nil {
+		return nil, fmt.Errorf("inserter is required")
+	}
+	hashes, err := b.InsertAll(context.Background(), inputs)
+	out := make([]string, len(hashes))
+	for i, h := range hashes {
+		out[i] = h.String()
+	}
+	return out, err
+}
+
 // NewInsertRecordInput creates a new InsertRecordInput struct
 func NewInsertRecordInput(client *tnclient.Client, streamId string, date int, val float64) types.InsertRecordInput {
 	dataProvider, err := GetCurrentAccount(client)

--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -237,25 +237,53 @@ func NewBulkInserter(client *tnclient.Client, batchSize int, maxInflight int, ma
 	return client.LoadBulkInserter(opts...)
 }
 
-// BulkInsertAll runs InsertAll against the given inserter and returns the
-// resulting tx hashes as hex strings (for Python consumption).
+// BulkInsertResult is the gopy-friendly return shape for BulkInsertAll.
 //
-// On failure, returns the partial hashes plus an error. Callers can extract
-// the failing chunk index by checking the error message format
-// "bulk insert failed at chunk N: ...".
-func BulkInsertAll(b *contractsapi.BulkInserter, inputs []types.InsertRecordInput) ([]string, error) {
-	if b == nil {
-		return nil, fmt.Errorf("inserter is required")
-	}
-	hashes, err := b.InsertAll(context.Background(), inputs)
-	out := make([]string, len(hashes))
-	for i, h := range hashes {
-		out[i] = h.String()
-	}
-	return out, err
+// It always carries TxHashes (the partial hashes broadcast so far) so that
+// Python callers can recover from a failure — gopy discards a (result, error)
+// tuple's result when the error is non-nil, hence the explicit struct.
+//
+// On success: ErrorMsg is "" and the other fields are zero.
+// On failure: ErrorMsg is the formatted error string, FailedChunkIndex is
+// either the index of the failing broadcast chunk (when DrainFailure is false)
+// or the total chunks broadcast (when DrainFailure is true).
+type BulkInsertResult struct {
+	TxHashes         []string
+	ErrorMsg         string
+	DrainFailure     bool
+	FailedChunkIndex int
 }
 
-// NewInsertRecordInput creates a new InsertRecordInput struct
+// BulkInsertAll runs InsertAll against the given inserter and returns a
+// BulkInsertResult that always carries the partial tx hashes (for recovery)
+// alongside any error info.
+func BulkInsertAll(b *contractsapi.BulkInserter, inputs []types.InsertRecordInput) *BulkInsertResult {
+	res := &BulkInsertResult{}
+	if b == nil {
+		res.ErrorMsg = "inserter is required"
+		return res
+	}
+	hashes, err := b.InsertAll(context.Background(), inputs)
+	res.TxHashes = make([]string, len(hashes))
+	for i, h := range hashes {
+		res.TxHashes[i] = h.String()
+	}
+	if err != nil {
+		res.ErrorMsg = err.Error()
+		var bie *contractsapi.BulkInsertError
+		if errors.As(err, &bie) {
+			res.DrainFailure = bie.DrainFailure
+			res.FailedChunkIndex = bie.FailedChunkIndex
+		}
+	}
+	return res
+}
+
+// NewInsertRecordInput creates a new InsertRecordInput struct.
+//
+// Resolves the data provider via GetCurrentAccount on every call. Suitable
+// for one-off inserts; for bulk paths, prefer NewInsertRecordInputForProvider
+// to avoid the per-record account lookup.
 func NewInsertRecordInput(client *tnclient.Client, streamId string, date int, val float64) types.InsertRecordInput {
 	dataProvider, err := GetCurrentAccount(client)
 	if err != nil {
@@ -263,6 +291,22 @@ func NewInsertRecordInput(client *tnclient.Client, streamId string, date int, va
 		return types.InsertRecordInput{}
 	}
 
+	return types.InsertRecordInput{
+		StreamId:     streamId,
+		DataProvider: dataProvider,
+		EventTime:    date,
+		Value:        val,
+	}
+}
+
+// NewInsertRecordInputForProvider creates an InsertRecordInput with an
+// explicit data provider, skipping the per-call GetCurrentAccount lookup.
+//
+// Use this when building many inputs for a single signer (the bulk insertion
+// path): resolve the data provider once via GetCurrentAccount, then call this
+// helper for each record. Avoids redundant account RPC roundtrips and makes
+// errors loud (the caller controls validation).
+func NewInsertRecordInputForProvider(dataProvider string, streamId string, date int, val float64) types.InsertRecordInput {
 	return types.InsertRecordInput{
 		StreamId:     streamId,
 		DataProvider: dataProvider,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -252,9 +252,16 @@ count, not by stream.
 
 #### Raises
 
-- `BulkInsertError` — chunk failed after exhausting retries. The message format is one of:
-  - `"bulk insert failed at chunk N: <reason>"` — broadcast for chunk N failed; resume from `inputs[N*batch_size:]`.
-  - `"bulk insert drain failed after N chunks broadcast: <reason>"` — all chunks broadcast successfully but `WaitTx` failed; the network is congested or the node is unreachable.
+`BulkInsertError` — chunk failed after exhausting retries. The exception carries:
+
+- `tx_hashes: List[str]` — tx hashes broadcast successfully before the failure
+- `drain_failure: bool` — `True` when all chunks broadcast but the final `WaitTx` failed
+- `failed_chunk_index: int` — index of the failing chunk (broadcast failure) or total chunks broadcast (drain failure)
+
+Use these to recover: when `drain_failure` is `False`, resume from
+`records[failed_chunk_index * batch_size:]` after fixing the underlying issue.
+When `drain_failure` is `True`, all hashes are in `tx_hashes` — investigate
+inclusion separately (the broadcast itself succeeded).
 
 #### Example
 
@@ -279,6 +286,10 @@ try:
     print(f"broadcast {len(tx_hashes)} transactions")
 except BulkInsertError as e:
     print(f"bulk insert failed: {e}")
+    print(f"  partial hashes: {len(e.tx_hashes)}")
+    print(f"  failed at chunk: {e.failed_chunk_index}")
+    print(f"  drain failure: {e.drain_failure}")
+    # If !e.drain_failure, resume from records[e.failed_chunk_index * 10:]
 ```
 
 #### Constraints

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -220,6 +220,83 @@ batches = [
 tx_hash = client.batch_insert_records(batches)
 ```
 
+### `BulkInserter` — high-throughput pipelined insertion
+
+When you need to push hundreds or thousands of records from a single signer,
+use `BulkInserter` instead of looping `batch_insert_records`. It caches the
+nonce locally and broadcasts each chunk fire-and-forget — admission (~50ms)
+becomes the rate limit instead of inclusion (~1–2s per block).
+
+#### `BulkInserter(client, batch_size=10, max_inflight=200, max_attempts=5)`
+
+Wraps the sdk-go `BulkInserter` (see
+[`sdk-go/core/contractsapi/bulk_inserter.go`](https://github.com/trufnetwork/sdk-go/blob/main/core/contractsapi/bulk_inserter.go)).
+Mirrors the cached-nonce pattern from `node/extensions/tn_attestation/extension.go`
+(PR `kwilteam/node#1356`) which solves the same problem on the node side.
+
+#### Parameters
+
+- `client: TNClient` — must use HTTP transport (the default).
+- `batch_size: int = 10` — records per `insert_records` transaction. Must be ≤ the protocol cap (currently 10).
+- `max_inflight: int = 200` — broadcasts queued before draining via `WaitTx`.
+- `max_attempts: int = 5` — initial attempt + retries per chunk on transient errors (`invalid nonce`, `mempool full`).
+
+#### `inserter.insert_all(batches: List[RecordBatch]) -> List[str]`
+
+Flattens `batches` into a single record list, chunks by `batch_size`,
+broadcasts each chunk pipelined, and drains every `max_inflight` plus once at
+the end. Returns the tx hashes in submission order.
+
+Records may mix stream IDs within a chunk — the inserter chunks by total record
+count, not by stream.
+
+#### Raises
+
+- `BulkInsertError` — chunk failed after exhausting retries. The message format is one of:
+  - `"bulk insert failed at chunk N: <reason>"` — broadcast for chunk N failed; resume from `inputs[N*batch_size:]`.
+  - `"bulk insert drain failed after N chunks broadcast: <reason>"` — all chunks broadcast successfully but `WaitTx` failed; the network is congested or the node is unreachable.
+
+#### Example
+
+```python
+from trufnetwork_sdk_py import TNClient, BulkInserter, BulkInsertError
+
+client = TNClient("https://gateway.testnet.truf.network", "YOUR_PRIVATE_KEY")
+inserter = BulkInserter(client)
+
+batches = [
+    {
+        "stream_id": "st...",
+        "inputs": [
+            {"date": 1700000000, "value": 1.5},
+            # ... thousands more
+        ],
+    },
+]
+
+try:
+    tx_hashes = inserter.insert_all(batches)
+    print(f"broadcast {len(tx_hashes)} transactions")
+except BulkInsertError as e:
+    print(f"bulk insert failed: {e}")
+```
+
+#### Constraints
+
+- **One BulkInserter per signer key.** The cache is per-instance; concurrent
+  inserters from the same signer collide on nonces because the mempool admits
+  transactions strictly in nonce order.
+- **Sequential per signer, not concurrent.** Out-of-order HTTP arrival from
+  one signer triggers `invalid nonce` rejections; the helper is single-threaded
+  by design.
+- **Different signers run in parallel.** Per-signer nonces are independent.
+
+#### Working example
+
+See [`examples/bulk_insert_example`](../examples/bulk_insert_example) for a
+full lifecycle demo: connect → drop existing → deploy → bulk-insert → fetch +
+verify → drop.
+
 ## Stream Querying
 
 ### `client.get_records(stream_id: str, **kwargs) -> List[Dict]`

--- a/examples/bulk_insert_example/README.md
+++ b/examples/bulk_insert_example/README.md
@@ -1,0 +1,101 @@
+# Bulk Insert Example (Python)
+
+Demonstrates `BulkInserter` — pipelined high-throughput record insertion that
+keeps a single signer within the protocol's 10-row-per-tx cap while
+broadcasting hundreds of transactions per minute.
+
+## What it does
+
+1. Connects to a local TN node with the dev private key
+2. Generates a stream ID and best-effort drops any existing stream with that ID
+3. Deploys a fresh primitive stream
+4. Bulk-inserts 25 synthetic records via `BulkInserter` (3 chunks of 10/10/5)
+5. Reads the records back and confirms count + values
+6. Drops the test stream
+
+## Why use BulkInserter
+
+Calling `client.batch_insert_records(...)` in a loop forces the SDK to wait for
+each transaction to be **included in a block** (~1–2s per call) before
+broadcasting the next. For 1,000 records that's 25+ minutes; for the Truflation
+CPI ingestor's ~17,000-record runs, it's 4–5 hours.
+
+`BulkInserter` instead:
+
+- Caches the nonce locally (one initial fetch, then increments)
+- Broadcasts each chunk fire-and-forget (`wait=False` underneath) — admission
+  takes ~50ms versus inclusion's 1–2s
+- Drains inflight hashes in batches via `wait_for_tx`
+- Retries automatically on `invalid nonce` (resets the cache and refetches)
+  and `mempool full` (backs off, keeps the cache)
+
+Result: 1,000 records land in roughly one minute on a typical node, instead of
+half an hour.
+
+## Prerequisites
+
+A local node with migrations applied + the dev key whitelisted. From the
+`node` repo:
+
+```bash
+task single:start                                                  # spin up postgres + tn-db
+PATH="$(pwd)/.build:$PATH" task action:migrate:dev                 # apply migrations + grant network_writer
+```
+
+The dev key is `0000000000000000000000000000000000000000000000000000000000000001`,
+which derives to address `0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf`. Both
+`task action:migrate:dev` and the `single:start` defaults wire this address as
+the DB owner and grant it `system:network_writer`.
+
+## Running
+
+From the `sdk-py` repo:
+
+```bash
+source .venv/bin/activate
+python examples/bulk_insert_example/main.py
+```
+
+## Expected output
+
+```
+connected as 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
+stream id: stbulkinsertxxxxxxxxxxxxxxxxxxxxx
+   (no existing stream to drop: ...)
+stream deployed (tx 0x...)
+broadcasting 25 records via BulkInserter (batch_size=10)...
+done: 3 chunks broadcast + drained in 1.05s (350ms/chunk avg)
+
+First 3 records read back:
+  EventTime=1704067200 Value=1.000000000000000000
+  EventTime=1704153600 Value=2.000000000000000000
+  EventTime=1704240000 Value=3.000000000000000000
+...
+Total verified: 25 records
+   dropped existing stream (tx 0x...)
+```
+
+## Customizing
+
+- **Larger workloads**: change `NUM_RECORDS` at the top of `main.py`. Chunks =
+  `ceil(NUM_RECORDS / 10)`.
+- **Throughput knobs**: pass kwargs to `BulkInserter`:
+
+  ```python
+  inserter = BulkInserter(
+      client,
+      batch_size=10,      # records per insert_records tx; protocol cap is 10
+      max_inflight=500,   # broadcasts queued before forced drain
+      max_attempts=5,     # initial + retries on transient errors
+  )
+  ```
+- **Testnet/mainnet**: change `TEST_PROVIDER_URL` and the private key. Note
+  that the account must hold `system:network_writer` to deploy streams.
+
+## Related
+
+- Python wrapper source: [`src/trufnetwork_sdk_py/bulk_inserter.py`](../../src/trufnetwork_sdk_py/bulk_inserter.py)
+- Underlying Go implementation: [`sdk-go/core/contractsapi/bulk_inserter.go`](https://github.com/trufnetwork/sdk-go/blob/main/core/contractsapi/bulk_inserter.go)
+- Pattern reference: [`tn_attestation/extension.go`](https://github.com/trufnetwork/node/blob/main/extensions/tn_attestation/extension.go)
+  in the node repo (PR #1356) — same cached-nonce design that solved the
+  attestation cron's "invalid nonce" noise.

--- a/examples/bulk_insert_example/README.md
+++ b/examples/bulk_insert_example/README.md
@@ -58,7 +58,7 @@ python examples/bulk_insert_example/main.py
 
 ## Expected output
 
-```
+```text
 connected as 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf
 stream id: stbulkinsertxxxxxxxxxxxxxxxxxxxxx
    (no existing stream to drop: ...)

--- a/examples/bulk_insert_example/main.py
+++ b/examples/bulk_insert_example/main.py
@@ -82,9 +82,10 @@ def main() -> None:
             return
         duration = time.time() - start
 
+        chunks = max(len(tx_hashes), 1)
         print(
             f"done: {len(tx_hashes)} chunks broadcast + drained in {duration:.2f}s "
-            f"({duration / len(tx_hashes) * 1000:.0f}ms/chunk avg)"
+            f"({duration / chunks * 1000:.0f}ms/chunk avg)"
         )
 
         # 5. Read back and confirm

--- a/examples/bulk_insert_example/main.py
+++ b/examples/bulk_insert_example/main.py
@@ -1,0 +1,111 @@
+"""
+BulkInserter example — pipelined high-throughput record insertion.
+
+Flow:
+  1. Connect to a local node with the dev private key
+  2. Generate a stream ID; if a stream with that ID already exists, drop it
+  3. Deploy a fresh primitive stream
+  4. Bulk-insert 25 records via BulkInserter (3 chunks of 10/10/5)
+  5. Read the records back and confirm the count + values
+  6. Drop the test stream
+
+Run against a local node spun up with `task single:start` from the node repo.
+The dev key already has system:network_writer (granted by `task action:migrate:dev`).
+"""
+
+import time
+from datetime import datetime, timedelta, timezone
+
+from trufnetwork_sdk_py import (
+    BulkInserter,
+    BulkInsertError,
+    STREAM_TYPE_PRIMITIVE,
+    TNClient,
+)
+from trufnetwork_sdk_py.utils import generate_stream_id
+
+# Test-only private key. NEVER use this for real funds.
+TEST_PRIVATE_KEY = "0000000000000000000000000000000000000000000000000000000000000001"
+TEST_PROVIDER_URL = "http://localhost:8484"
+NUM_RECORDS = 25
+
+
+def _date_to_unix(date: datetime) -> int:
+    return int(date.replace(tzinfo=timezone.utc).timestamp())
+
+
+def _safe_drop(client: TNClient, stream_id: str) -> None:
+    """Best-effort drop — never raises."""
+    try:
+        tx_hash = client.destroy_stream(stream_id)
+        client.wait_for_tx(tx_hash)
+        print(f"   dropped existing stream (tx {tx_hash})")
+    except Exception as e:
+        print(f"   (no existing stream to drop: {e})")
+
+
+def main() -> None:
+    # 1. Connect
+    client = TNClient(TEST_PROVIDER_URL, TEST_PRIVATE_KEY)
+    print(f"connected as {client.get_current_account()}")
+
+    # 2. Generate stream id + best-effort drop
+    stream_id = generate_stream_id("bulk-insert-example")
+    print(f"stream id: {stream_id}")
+    _safe_drop(client, stream_id)
+
+    # 3. Deploy fresh primitive stream
+    deploy_tx = client.deploy_stream(stream_id, STREAM_TYPE_PRIMITIVE)
+    client.wait_for_tx(deploy_tx)
+    print(f"stream deployed (tx {deploy_tx})")
+
+    try:
+        # 4. Bulk-insert via BulkInserter
+        inserter = BulkInserter(client)
+
+        start_date = datetime(2024, 1, 1)
+        records = [
+            {
+                "date": _date_to_unix(start_date + timedelta(days=i)),
+                "value": float(i + 1),  # +1 to avoid zero (filtered by consensus)
+            }
+            for i in range(NUM_RECORDS)
+        ]
+        batches = [{"stream_id": stream_id, "inputs": records}]
+
+        print(f"broadcasting {NUM_RECORDS} records via BulkInserter (batch_size=10)...")
+        start = time.time()
+        try:
+            tx_hashes = inserter.insert_all(batches)
+        except BulkInsertError as e:
+            print(f"bulk insert failed: {e}")
+            return
+        duration = time.time() - start
+
+        print(
+            f"done: {len(tx_hashes)} chunks broadcast + drained in {duration:.2f}s "
+            f"({duration / len(tx_hashes) * 1000:.0f}ms/chunk avg)"
+        )
+
+        # 5. Read back and confirm
+        retrieved = client.get_records(
+            stream_id=stream_id,
+            data_provider=client.get_current_account(),
+            date_from=_date_to_unix(datetime(2023, 1, 1)),
+        )
+
+        if len(retrieved) != NUM_RECORDS:
+            print(f"record count mismatch: got {len(retrieved)}, want {NUM_RECORDS}")
+            return
+
+        print("\nFirst 3 records read back:")
+        for r in retrieved[:3]:
+            print(f"  EventTime={r['EventTime']} Value={r['Value']}")
+        print(f"...\nTotal verified: {len(retrieved)} records")
+    finally:
+        # 6. Cleanup
+        _safe_drop(client, stream_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260216231327-01b863886682
-	github.com/trufnetwork/sdk-go v0.6.4-0.20260415132719-cc9782d35c67
+	github.com/trufnetwork/sdk-go v0.6.5-0.20260417151855-69dbc4701dec
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,10 @@ github.com/trufnetwork/sdk-go v0.6.4-0.20260409133033-e38300939ecd h1:rMrn7FBS2Z
 github.com/trufnetwork/sdk-go v0.6.4-0.20260409133033-e38300939ecd/go.mod h1:f7IjKRZi4VufWM01b3rODFot1LqopiKw5YR23TL/3dg=
 github.com/trufnetwork/sdk-go v0.6.4-0.20260415132719-cc9782d35c67 h1:zyi3fluc2zWDcnQmsFYPQyfiNLTN8hrViaGguT99gB4=
 github.com/trufnetwork/sdk-go v0.6.4-0.20260415132719-cc9782d35c67/go.mod h1:f7IjKRZi4VufWM01b3rODFot1LqopiKw5YR23TL/3dg=
+github.com/trufnetwork/sdk-go v0.6.4 h1:4EzPkwn2WowhWniT2TINu2tjYsrIYidj2+kkT0QpThY=
+github.com/trufnetwork/sdk-go v0.6.4/go.mod h1:f7IjKRZi4VufWM01b3rODFot1LqopiKw5YR23TL/3dg=
+github.com/trufnetwork/sdk-go v0.6.5-0.20260417151855-69dbc4701dec h1:D7iJ6v4TaRh8EZROhtTV5JR37rYCDtD88MuG2VGMtbo=
+github.com/trufnetwork/sdk-go v0.6.5-0.20260417151855-69dbc4701dec/go.mod h1:f7IjKRZi4VufWM01b3rODFot1LqopiKw5YR23TL/3dg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/src/trufnetwork_sdk_py/__init__.py
+++ b/src/trufnetwork_sdk_py/__init__.py
@@ -1,3 +1,4 @@
+from .bulk_inserter import BulkInserter, BulkInsertError
 from .client import (
     TNClient,
     LocalClient,
@@ -34,4 +35,6 @@ __all__ = [
     "STREAM_TYPE_COMPOSED",
     "VISIBILITY_PUBLIC",
     "VISIBILITY_PRIVATE",
+    "BulkInserter",
+    "BulkInsertError",
 ]

--- a/src/trufnetwork_sdk_py/bulk_inserter.py
+++ b/src/trufnetwork_sdk_py/bulk_inserter.py
@@ -1,0 +1,126 @@
+"""
+BulkInserter — pipelined high-throughput insert helper.
+
+Wraps the sdk-go BulkInserter (`sdk-go/core/contractsapi/bulk_inserter.go`)
+which mirrors the cached-nonce + fire-and-forget pattern from
+`node/extensions/tn_attestation/extension.go` (PR kwilteam/node#1356).
+
+Use this instead of looping `client.batch_insert_records(...)` when you
+need to push more than a few hundred records — the underlying SDK forces a
+wait-for-inclusion between every broadcast, which serializes throughput to
+~one tx per block (1-2s). BulkInserter caches the nonce locally and uses
+fire-and-forget broadcasts so admission (~50ms) becomes the rate limit
+instead of inclusion.
+
+Example:
+
+    from trufnetwork_sdk_py import TNClient, BulkInserter, RecordBatch
+
+    client = TNClient(provider_url, private_key)
+    inserter = BulkInserter(client)
+
+    batches: list[RecordBatch] = [
+        {"stream_id": "...", "inputs": [{"date": 1700000000, "value": 1.5}, ...]},
+        ...
+    ]
+    tx_hashes = inserter.insert_all(batches)
+
+Constraints:
+- One BulkInserter per signer key. Concurrent inserters from the same
+  signer will collide on nonces (mempool admits strictly in-order;
+  out-of-order broadcasts are rejected).
+- Inputs are flattened, then chunked into `batch_size` (default 10) per tx.
+"""
+
+from typing import List, Optional
+
+import trufnetwork_sdk_c_bindings.exports as truf_sdk
+
+from .client import RecordBatch, TNClient
+
+
+class BulkInsertError(Exception):
+    """Raised when BulkInserter fails to broadcast a chunk after exhausting
+    retries.
+
+    The underlying error message includes the failing chunk index in the
+    format "bulk insert failed at chunk N: <reason>", e.g. so callers can
+    parse it if they want to resume from that chunk.
+    """
+
+    pass
+
+
+class BulkInserter:
+    """Pipelined batch inserter for high-throughput record ingestion.
+
+    Parameters
+    ----------
+    client : TNClient
+        The TN client to broadcast through. Must use HTTP transport (the
+        default).
+    batch_size : int, default 10
+        Records per insert_records transaction. Must be <= the protocol cap
+        (currently 10).
+    max_inflight : int, default 200
+        How many broadcasts may queue before draining via WaitTx.
+    max_attempts : int, default 5
+        Max attempts per chunk (initial + retries) on transient errors
+        (invalid nonce, mempool full).
+    """
+
+    def __init__(
+        self,
+        client: TNClient,
+        batch_size: int = 10,
+        max_inflight: int = 200,
+        max_attempts: int = 5,
+    ):
+        if client is None:
+            raise ValueError("client is required")
+        # Pass 0 for any value to use the Go-side defaults.
+        self._inner = truf_sdk.NewBulkInserter(
+            client.client, batch_size, max_inflight, max_attempts
+        )
+        self._client = client
+
+    def insert_all(self, batches: List[RecordBatch]) -> List[str]:
+        """Broadcast all records pipelined and return the tx hashes in
+        submission order.
+
+        Records are flattened across batches and chunked by batch_size.
+        Each chunk becomes one insert_records transaction.
+
+        On chunk failure after retries, raises BulkInsertError. The
+        message includes the failing chunk index.
+        """
+        if not batches:
+            return []
+
+        # Flatten batches into a single list of InsertRecordInput Go
+        # structs (one per record). Each input carries its own stream_id +
+        # data_provider, so chunks may mix streams.
+        go_inputs = []
+        for batch in batches:
+            stream_id = batch["stream_id"]
+            for record in batch["inputs"]:
+                go_inputs.append(
+                    truf_sdk.NewInsertRecordInput(
+                        self._client.client,
+                        stream_id,
+                        record["date"],
+                        record["value"],
+                    )
+                )
+
+        if not go_inputs:
+            return []
+
+        go_input_slice = truf_sdk.Slice_s1_types_InsertRecordInput(go_inputs)
+        try:
+            hashes = truf_sdk.BulkInsertAll(self._inner, go_input_slice)
+        except Exception as e:
+            raise BulkInsertError(str(e)) from e
+
+        # gopy returns a Go slice; convert to plain Python list of strings.
+        return list(hashes)

--- a/src/trufnetwork_sdk_py/bulk_inserter.py
+++ b/src/trufnetwork_sdk_py/bulk_inserter.py
@@ -40,15 +40,35 @@ from .client import RecordBatch, TNClient
 
 
 class BulkInsertError(Exception):
-    """Raised when BulkInserter fails to broadcast a chunk after exhausting
-    retries.
+    """Raised when BulkInserter fails to broadcast a chunk or drain inflight
+    transactions after exhausting retries.
 
-    The underlying error message includes the failing chunk index in the
-    format "bulk insert failed at chunk N: <reason>", e.g. so callers can
-    parse it if they want to resume from that chunk.
+    Attributes
+    ----------
+    tx_hashes : list[str]
+        Tx hashes broadcast successfully before the failure. Use this to
+        recover: when ``drain_failure`` is False, resume the workload from
+        ``records[failed_chunk_index * batch_size:]``.
+    drain_failure : bool
+        True when all chunks were broadcast successfully but the final
+        ``WaitTx`` drain failed. In that case ``tx_hashes`` is the full set
+        of submitted hashes — investigate inclusion separately.
+    failed_chunk_index : int
+        Index of the failing chunk (when ``drain_failure`` is False) or the
+        total number of chunks broadcast (when ``drain_failure`` is True).
     """
 
-    pass
+    def __init__(
+        self,
+        message: str,
+        tx_hashes: Optional[List[str]] = None,
+        drain_failure: bool = False,
+        failed_chunk_index: int = 0,
+    ):
+        super().__init__(message)
+        self.tx_hashes: List[str] = list(tx_hashes) if tx_hashes else []
+        self.drain_failure = drain_failure
+        self.failed_chunk_index = failed_chunk_index
 
 
 class BulkInserter:
@@ -92,21 +112,37 @@ class BulkInserter:
         Each chunk becomes one insert_records transaction.
 
         On chunk failure after retries, raises BulkInsertError. The
-        message includes the failing chunk index.
+        exception carries the partial tx hashes (``tx_hashes`` attribute),
+        the failing chunk index (``failed_chunk_index``), and a flag
+        indicating whether the failure was during broadcast or during the
+        final drain (``drain_failure``).
         """
         if not batches:
             return []
 
-        # Flatten batches into a single list of InsertRecordInput Go
-        # structs (one per record). Each input carries its own stream_id +
-        # data_provider, so chunks may mix streams.
+        # Resolve the data provider ONCE, not per record. NewInsertRecordInput
+        # in the Go binding calls GetCurrentAccount on every invocation —
+        # cheap individually, but for thousands of records that's thousands
+        # of redundant lookups, and a transient failure would silently
+        # produce zero-valued inputs.
+        data_provider = self._client.get_current_account()
+        if not data_provider:
+            raise BulkInsertError(
+                "could not resolve data provider for the current signer"
+            )
+
+        # Flatten batches into a single list of InsertRecordInput Go structs
+        # (one per record). Each input carries its own stream_id + data
+        # provider, so chunks may mix streams.
         go_inputs = []
         for batch in batches:
             stream_id = batch["stream_id"]
+            if not stream_id:
+                raise BulkInsertError("batch is missing stream_id")
             for record in batch["inputs"]:
                 go_inputs.append(
-                    truf_sdk.NewInsertRecordInput(
-                        self._client.client,
+                    truf_sdk.NewInsertRecordInputForProvider(
+                        data_provider,
                         stream_id,
                         record["date"],
                         record["value"],
@@ -117,10 +153,18 @@ class BulkInserter:
             return []
 
         go_input_slice = truf_sdk.Slice_s1_types_InsertRecordInput(go_inputs)
-        try:
-            hashes = truf_sdk.BulkInsertAll(self._inner, go_input_slice)
-        except Exception as e:
-            raise BulkInsertError(str(e)) from e
+        result = truf_sdk.BulkInsertAll(self._inner, go_input_slice)
 
-        # gopy returns a Go slice; convert to plain Python list of strings.
-        return list(hashes)
+        # Always materialize hashes — gopy gives us a Go slice; copy to a
+        # plain Python list for safe handling regardless of success/failure.
+        tx_hashes = list(result.TxHashes) if result.TxHashes else []
+
+        if result.ErrorMsg:
+            raise BulkInsertError(
+                result.ErrorMsg,
+                tx_hashes=tx_hashes,
+                drain_failure=result.DrainFailure,
+                failed_chunk_index=result.FailedChunkIndex,
+            )
+
+        return tx_hashes

--- a/tests/test_bulk_inserter.py
+++ b/tests/test_bulk_inserter.py
@@ -1,0 +1,159 @@
+"""
+Integration tests for the BulkInserter Python wrapper.
+
+The Go-side BulkInserter has full unit coverage in
+sdk-go/core/contractsapi/bulk_inserter_test.go — these tests focus on the
+Python wrapper plumbing:
+- constructor null check
+- empty input short-circuits
+- end-to-end record insertion against a real node
+- post-insertion records are readable
+- failure modes propagate as BulkInsertError
+"""
+
+import time
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+import pytest
+import trufnetwork_sdk_c_bindings.exports as truf_sdk
+
+from tests.fixtures.test_trufnetwork import DEFAULT_TN_PRIVATE_KEY, tn_node
+from trufnetwork_sdk_py import BulkInserter, BulkInsertError
+from trufnetwork_sdk_py.client import Record, RecordBatch, TNClient
+from trufnetwork_sdk_py.utils import generate_stream_id
+
+
+@pytest.fixture(scope="module")
+def client(tn_node, grant_network_writer):
+    c = TNClient(tn_node, DEFAULT_TN_PRIVATE_KEY)
+    grant_network_writer(c)
+    return c
+
+
+def _safe_destroy(client, stream_id):
+    if stream_id is None:
+        return
+    try:
+        client.destroy_stream(stream_id)
+    except Exception:
+        pass
+
+
+def _date_to_unix(date: datetime) -> int:
+    return int(date.replace(tzinfo=timezone.utc).timestamp())
+
+
+# --- pure unit tests (no node required) ---
+
+
+def test_constructor_rejects_none_client():
+    with pytest.raises(ValueError, match="client is required"):
+        BulkInserter(None)
+
+
+# --- integration tests (require tn_node) ---
+
+
+def test_insert_all_empty_batches_returns_empty(client):
+    inserter = BulkInserter(client)
+    assert inserter.insert_all([]) == []
+
+
+def test_insert_all_empty_inputs_returns_empty(client):
+    inserter = BulkInserter(client)
+    # batches with empty inputs lists should also short-circuit
+    assert inserter.insert_all([{"stream_id": "x", "inputs": []}]) == []
+
+
+def test_insert_all_inserts_and_reads_back(client):
+    """End-to-end: BulkInserter → insert 25 records → read back → verify."""
+    stream_id = generate_stream_id("test_bulk_inserter_e2e")
+    _safe_destroy(client, stream_id)
+
+    try:
+        client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive)
+
+        NUM_RECORDS = 25
+        start_date = datetime(2024, 1, 1)
+        records: List[Record] = [
+            Record(
+                date=_date_to_unix(start_date + timedelta(days=i)),
+                value=float(i + 1),  # +1 to avoid zero (filtered by consensus)
+            )
+            for i in range(NUM_RECORDS)
+        ]
+        batches: List[RecordBatch] = [RecordBatch(stream_id=stream_id, inputs=records)]
+
+        inserter = BulkInserter(client)
+        start = time.time()
+        tx_hashes = inserter.insert_all(batches)
+        duration = time.time() - start
+
+        # 25 records / 10 per batch = 3 chunks (10, 10, 5)
+        assert len(tx_hashes) == 3, f"expected 3 chunks, got {len(tx_hashes)}"
+        assert all(isinstance(h, str) and len(h) > 0 for h in tx_hashes)
+
+        print(
+            f"[BulkInserter E2E] {NUM_RECORDS} records in 3 chunks: {duration:.2f}s "
+            f"(avg {(duration / 3) * 1000:.0f}ms per chunk)"
+        )
+
+        # Read back and verify all records present
+        retrieved = client.get_records(
+            stream_id,
+            data_provider=client.get_current_account(),
+            date_from=_date_to_unix(datetime(2023, 1, 1)),
+        )
+        assert len(retrieved) == NUM_RECORDS
+
+        retrieved_dates = sorted(int(r["EventTime"]) for r in retrieved)
+        expected_dates = sorted(r["date"] for r in records)
+        assert retrieved_dates == expected_dates
+    finally:
+        _safe_destroy(client, stream_id)
+
+
+def test_insert_all_single_chunk_under_batch_size(client):
+    """A single chunk under the batch_size still goes through the pipeline."""
+    stream_id = generate_stream_id("test_bulk_inserter_small")
+    _safe_destroy(client, stream_id)
+
+    try:
+        client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive)
+
+        records = [Record(date=_date_to_unix(datetime(2024, 6, i + 1)), value=float(i + 1)) for i in range(3)]
+        batches = [RecordBatch(stream_id=stream_id, inputs=records)]
+
+        inserter = BulkInserter(client)
+        tx_hashes = inserter.insert_all(batches)
+
+        assert len(tx_hashes) == 1
+        retrieved = client.get_records(
+            stream_id,
+            data_provider=client.get_current_account(),
+            date_from=_date_to_unix(datetime(2023, 1, 1)),
+        )
+        assert len(retrieved) == 3
+    finally:
+        _safe_destroy(client, stream_id)
+
+
+def test_insert_all_custom_batch_size(client):
+    """Verify batch_size override produces the expected number of chunks."""
+    stream_id = generate_stream_id("test_bulk_inserter_bsize")
+    _safe_destroy(client, stream_id)
+
+    try:
+        client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive)
+
+        # 14 records, batch_size=5 → 5+5+4 = 3 chunks
+        records = [Record(date=_date_to_unix(datetime(2024, 7, i + 1)), value=float(i + 1)) for i in range(14)]
+        batches = [RecordBatch(stream_id=stream_id, inputs=records)]
+
+        inserter = BulkInserter(client, batch_size=5)
+        tx_hashes = inserter.insert_all(batches)
+
+        assert len(tx_hashes) == 3
+    finally:
+        _safe_destroy(client, stream_id)

--- a/tests/test_bulk_inserter.py
+++ b/tests/test_bulk_inserter.py
@@ -16,10 +16,9 @@ from datetime import datetime, timedelta, timezone
 from typing import List
 
 import pytest
-import trufnetwork_sdk_c_bindings.exports as truf_sdk
 
 from tests.fixtures.test_trufnetwork import DEFAULT_TN_PRIVATE_KEY, tn_node
-from trufnetwork_sdk_py import BulkInserter, BulkInsertError
+from trufnetwork_sdk_py import BulkInserter, BulkInsertError, STREAM_TYPE_PRIMITIVE
 from trufnetwork_sdk_py.client import Record, RecordBatch, TNClient
 from trufnetwork_sdk_py.utils import generate_stream_id
 
@@ -72,7 +71,7 @@ def test_insert_all_inserts_and_reads_back(client):
     _safe_destroy(client, stream_id)
 
     try:
-        client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive)
+        client.deploy_stream(stream_id, stream_type=STREAM_TYPE_PRIMITIVE)
 
         NUM_RECORDS = 25
         start_date = datetime(2024, 1, 1)
@@ -120,7 +119,7 @@ def test_insert_all_single_chunk_under_batch_size(client):
     _safe_destroy(client, stream_id)
 
     try:
-        client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive)
+        client.deploy_stream(stream_id, stream_type=STREAM_TYPE_PRIMITIVE)
 
         records = [Record(date=_date_to_unix(datetime(2024, 6, i + 1)), value=float(i + 1)) for i in range(3)]
         batches = [RecordBatch(stream_id=stream_id, inputs=records)]
@@ -145,7 +144,7 @@ def test_insert_all_custom_batch_size(client):
     _safe_destroy(client, stream_id)
 
     try:
-        client.deploy_stream(stream_id, stream_type=truf_sdk.StreamTypePrimitive)
+        client.deploy_stream(stream_id, stream_type=STREAM_TYPE_PRIMITIVE)
 
         # 14 records, batch_size=5 → 5+5+4 = 3 chunks
         records = [Record(date=_date_to_unix(datetime(2024, 7, i + 1)), value=float(i + 1)) for i in range(14)]


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added BulkInserter utility for high-throughput, pipelined bulk record insertion with fire-and-forget broadcasting and automatic chunking.
  * Supports configurable parameters (batch size, max inflight, max attempts) with built-in retry and backoff handling for transient errors.

* **Documentation**
  * Added comprehensive API reference and practical examples demonstrating BulkInserter usage patterns and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->