### PR TITLE
chore: tune bulk insert backoff during node catch-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ broadcast, so 1,000 records can take 25+ minutes.
 
 `BulkInserter` instead caches the nonce locally and broadcasts each chunk
 fire-and-forget, draining inflight transactions in batches via `WaitTx`. It
-handles `invalid nonce` (resets cache, retries) and `mempool full` (backs off,
-keeps cache) automatically.
+handles `invalid nonce` (resets cache, retries), `mempool full` (backs off,
+keeps cache), and `node is catching up` (backs off with a longer base, keeps
+cache) automatically.
 
 ```python
 from trufnetwork_sdk_py import TNClient, BulkInserter, BulkInsertError
@@ -169,9 +170,13 @@ except BulkInsertError as e:
 ```python
 BulkInserter(
     client,
-    batch_size=10,      # records per insert_records tx; protocol cap is 10
-    max_inflight=200,   # broadcasts queued before forced drain via WaitTx
-    max_attempts=5,     # initial + retries on transient errors
+    batch_size=10,                # records per insert_records tx; protocol cap is 10
+    max_inflight=200,             # broadcasts queued before forced drain via WaitTx
+    max_attempts=5,               # initial + retries on transient errors
+                                  # (invalid nonce, mempool full, "node is catching up")
+    catchup_backoff_seconds=5,    # base backoff (sec) for "node is catching up";
+                                  # actual delay = base * (attempt + 1); default totals ~50s
+                                  # across 5 attempts. Bump for backends prone to longer lag.
 )
 ```
 

--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -219,9 +219,11 @@ func InsertRecords(client *tnclient.Client, inputs []types.InsertRecordInput) (s
 // batchSize: records per insert_records tx (must be <= protocol cap of 10).
 // maxInflight: how many broadcasts may queue before draining via WaitTx.
 // maxAttempts: max attempts per chunk (initial + retries) on transient
-// errors (invalid nonce, mempool full).
-// Pass 0 for any of these to use defaults (10, 200, 5).
-func NewBulkInserter(client *tnclient.Client, batchSize int, maxInflight int, maxAttempts int) (*contractsapi.BulkInserter, error) {
+// errors (invalid nonce, mempool full, "node is catching up").
+// catchupBackoffSeconds: base backoff in seconds for "node is catching up"
+// rejections. Actual delay is base * (attempt + 1).
+// Pass 0 for any of these to use defaults (10, 200, 5, 5s).
+func NewBulkInserter(client *tnclient.Client, batchSize int, maxInflight int, maxAttempts int, catchupBackoffSeconds int) (*contractsapi.BulkInserter, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client is required")
 	}
@@ -234,6 +236,9 @@ func NewBulkInserter(client *tnclient.Client, batchSize int, maxInflight int, ma
 	}
 	if maxAttempts > 0 {
 		opts = append(opts, contractsapi.WithMaxAttempts(maxAttempts))
+	}
+	if catchupBackoffSeconds > 0 {
+		opts = append(opts, contractsapi.WithCatchupBackoff(time.Duration(catchupBackoffSeconds)*time.Second))
 	}
 	return client.LoadBulkInserter(opts...)
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -227,7 +227,7 @@ use `BulkInserter` instead of looping `batch_insert_records`. It caches the
 nonce locally and broadcasts each chunk fire-and-forget — admission (~50ms)
 becomes the rate limit instead of inclusion (~1–2s per block).
 
-#### `BulkInserter(client, batch_size=10, max_inflight=200, max_attempts=5)`
+#### `BulkInserter(client, batch_size=10, max_inflight=200, max_attempts=5, catchup_backoff_seconds=5)`
 
 Wraps the sdk-go `BulkInserter` (see
 [`sdk-go/core/contractsapi/bulk_inserter.go`](https://github.com/trufnetwork/sdk-go/blob/main/core/contractsapi/bulk_inserter.go)).
@@ -239,7 +239,8 @@ Mirrors the cached-nonce pattern from `node/extensions/tn_attestation/extension.
 - `client: TNClient` — must use HTTP transport (the default).
 - `batch_size: int = 10` — records per `insert_records` transaction. Must be ≤ the protocol cap (currently 10).
 - `max_inflight: int = 200` — broadcasts queued before draining via `WaitTx`.
-- `max_attempts: int = 5` — initial attempt + retries per chunk on transient errors (`invalid nonce`, `mempool full`).
+- `max_attempts: int = 5` — initial attempt + retries per chunk on transient errors (`invalid nonce`, `mempool full`, `node is catching up`).
+- `catchup_backoff_seconds: int = 5` — base backoff in seconds when the broadcast backend rejects with `node is catching up`. Actual delay per attempt is `base * (attempt + 1)`, so the default totals ~50 s across 5 attempts. Bump this and/or `max_attempts` if the backend you're hitting is prone to longer catch-up events.
 
 #### `inserter.insert_all(batches: List[RecordBatch]) -> List[str]`
 

--- a/examples/bulk_insert_example/README.md
+++ b/examples/bulk_insert_example/README.md
@@ -26,8 +26,9 @@ CPI ingestor's ~17,000-record runs, it's 4–5 hours.
 - Broadcasts each chunk fire-and-forget (`wait=False` underneath) — admission
   takes ~50ms versus inclusion's 1–2s
 - Drains inflight hashes in batches via `wait_for_tx`
-- Retries automatically on `invalid nonce` (resets the cache and refetches)
-  and `mempool full` (backs off, keeps the cache)
+- Retries automatically on `invalid nonce` (resets the cache and refetches),
+  `mempool full` (backs off, keeps the cache), and `node is catching up` (backs
+  off with a longer base — typical catch-up events resolve in tens of seconds)
 
 Result: 1,000 records land in roughly one minute on a typical node, instead of
 half an hour.
@@ -84,9 +85,12 @@ Total verified: 25 records
   ```python
   inserter = BulkInserter(
       client,
-      batch_size=10,      # records per insert_records tx; protocol cap is 10
-      max_inflight=500,   # broadcasts queued before forced drain
-      max_attempts=5,     # initial + retries on transient errors
+      batch_size=10,                # records per insert_records tx; protocol cap is 10
+      max_inflight=500,             # broadcasts queued before forced drain
+      max_attempts=5,               # initial + retries on transient errors
+                                    # (invalid nonce, mempool full, "node is catching up")
+      catchup_backoff_seconds=5,    # base backoff (sec) for "node is catching up";
+                                    # bump for backends prone to longer lag events
   )
   ```
 - **Testnet/mainnet**: change `TEST_PROVIDER_URL` and the private key. Note

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8
-	github.com/trufnetwork/sdk-go v0.6.5-0.20260421115245-8b1861ca8642
+	github.com/trufnetwork/sdk-go v0.6.5-0.20260423124807-23b459426dae
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8 h1:fzkc
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/sdk-go v0.6.5-0.20260421115245-8b1861ca8642 h1:7+L63rjyeeI2FeXPVKl0eMeBf6gX7JAbNr9aHMKvE5U=
 github.com/trufnetwork/sdk-go v0.6.5-0.20260421115245-8b1861ca8642/go.mod h1:f7IjKRZi4VufWM01b3rODFot1LqopiKw5YR23TL/3dg=
+github.com/trufnetwork/sdk-go v0.6.5-0.20260423124807-23b459426dae h1:QeULY7CWYQ1BfOw6885Ch1UtnrDXH+IC2JgZHklTXig=
+github.com/trufnetwork/sdk-go v0.6.5-0.20260423124807-23b459426dae/go.mod h1:f7IjKRZi4VufWM01b3rODFot1LqopiKw5YR23TL/3dg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/src/trufnetwork_sdk_py/bulk_inserter.py
+++ b/src/trufnetwork_sdk_py/bulk_inserter.py
@@ -86,7 +86,13 @@ class BulkInserter:
         How many broadcasts may queue before draining via WaitTx.
     max_attempts : int, default 5
         Max attempts per chunk (initial + retries) on transient errors
-        (invalid nonce, mempool full).
+        (invalid nonce, mempool full, "node is catching up").
+    catchup_backoff_seconds : int, default 5
+        Base backoff in seconds when the broadcast backend rejects with
+        "node is catching up". Actual delay per attempt is base * (attempt + 1)
+        — defaults give a worst-case wait of ~50s across 5 attempts. Bump
+        this and/or ``max_attempts`` if the backend you're hitting is prone
+        to longer catch-up events.
     """
 
     def __init__(
@@ -95,12 +101,13 @@ class BulkInserter:
         batch_size: int = 10,
         max_inflight: int = 200,
         max_attempts: int = 5,
+        catchup_backoff_seconds: int = 5,
     ):
         if client is None:
             raise ValueError("client is required")
         # Pass 0 for any value to use the Go-side defaults.
         self._inner = truf_sdk.NewBulkInserter(
-            client.client, batch_size, max_inflight, max_attempts
+            client.client, batch_size, max_inflight, max_attempts, catchup_backoff_seconds
         )
         self._client = client
 


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3697