### PR TITLE
fix: resume-able bulk insert from failed chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,29 @@ BulkInserter(
     client,
     batch_size=10,                # records per insert_records tx; protocol cap is 10
     max_inflight=200,             # broadcasts queued before forced drain via WaitTx
-    max_attempts=5,               # initial + retries on transient errors
-                                  # (invalid nonce, mempool full, "node is catching up")
-    catchup_backoff_seconds=5,    # base backoff (sec) for "node is catching up";
-                                  # actual delay = base * (attempt + 1); default totals ~50s
-                                  # across 5 attempts. Bump for backends prone to longer lag.
+    max_attempts=15,              # initial + retries per chunk on non-catchup transient
+                                  # errors (invalid nonce, mempool full); ~3.5 min wait
+                                  # per chunk before bubbling up
+    catchup_backoff_seconds=15,   # base backoff (sec) for "node is catching up";
+                                  # actual delay = base * (attempt + 1)
+    catchup_max_attempts=20,      # separate budget for catch-up errors; with the 15s base
+                                  # gives a worst-case ~47.5 min wait per chunk (20 attempts,
+                                  # 19 backoffs at 15s..285s) before bubbling up. Catch-up
+                                  # events on a public RPC routinely run minutes long;
+                                  # sharing the transient budget aborted multi-hour bulk
+                                  # loads in earlier versions.
+    infra_max_attempts=10,        # pre-broadcast infra errors only (KGW "no available
+                                  # backend", TCP "connection refused", DNS "no such host").
+                                  # Safe to retry because the request never reached kwild.
+                                  # Mid-request errors (EOF, connection reset, context
+                                  # deadline) stay fatal at the SDK layer — retrying could
+                                  # double-broadcast and duplicate inserts; the caller's
+                                  # resume layer recovers them safely via partial-progress
+                                  # slicing instead.
+    progress_log_every_n=500,     # emit INFO progress line every N chunks (chunks done /
+                                  # total, rows done, elapsed, chunks/sec, ETA);
+                                  # 0 disables. Logged via the Go-side stderr logger,
+                                  # captured by Prefect's task-log subprocess wrapper.
 )
 ```
 

--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/trufnetwork/kwil-db/core/crypto"
 	"github.com/trufnetwork/kwil-db/core/crypto/auth"
+	kwillog "github.com/trufnetwork/kwil-db/core/log"
 	kwilTypes "github.com/trufnetwork/kwil-db/core/types"
 	"github.com/trufnetwork/sdk-go/core/contractsapi"
 	"github.com/trufnetwork/sdk-go/core/tnclient"
@@ -216,18 +218,50 @@ func InsertRecords(client *tnclient.Client, inputs []types.InsertRecordInput) (s
 // NewBulkInserter constructs a BulkInserter wired to the given TNClient.
 // Wraps tnclient.Client.LoadBulkInserter for gopy export to Python.
 //
-// batchSize: records per insert_records tx (must be <= protocol cap of 10).
-// maxInflight: how many broadcasts may queue before draining via WaitTx.
-// maxAttempts: max attempts per chunk (initial + retries) on transient
-// errors (invalid nonce, mempool full, "node is catching up").
-// catchupBackoffSeconds: base backoff in seconds for "node is catching up"
-// rejections. Actual delay is base * (attempt + 1).
-// Pass 0 for any of these to use defaults (10, 200, 5, 5s).
-func NewBulkInserter(client *tnclient.Client, batchSize int, maxInflight int, maxAttempts int, catchupBackoffSeconds int) (*contractsapi.BulkInserter, error) {
+// Tuning args (pass 0 for any to use defaults shown):
+//
+//	batchSize             records per insert_records tx (cap=10)              default 10
+//	maxInflight           broadcasts queued before WaitTx drain               default 200
+//	maxAttempts           retries per chunk on invalid-nonce/mempool          default 15
+//	catchupBackoffSeconds base linear backoff for "node is catching up"       default 15
+//	catchupMaxAttempts    retries per chunk on "catching up" specifically     default 20
+//	infraMaxAttempts      retries per chunk on pre-broadcast infra errors     default 10
+//	                      ("no available backend", "connection refused",
+//	                      "no such host"); reuses retryBackoff for sleep
+//	progressLogEveryN     emit INFO progress line every N chunks (0=off)      default 0
+//
+// The logger is wired to stderr at INFO level so the prefect.engine
+// subprocess captures BulkInserter WARN lines (catchup/nonce/mempool retries)
+// and progress logs in its task logs — without this, the Python wrapper sees
+// only "Submitting N records" at the start and either success or
+// BulkInsertError at the end, with hours of silence in between.
+func NewBulkInserter(
+	client *tnclient.Client,
+	batchSize int,
+	maxInflight int,
+	maxAttempts int,
+	catchupBackoffSeconds int,
+	catchupMaxAttempts int,
+	infraMaxAttempts int,
+	progressLogEveryN int,
+) (*contractsapi.BulkInserter, error) {
 	if client == nil {
 		return nil, fmt.Errorf("client is required")
 	}
-	var opts []contractsapi.BulkInserterOption
+	opts := []contractsapi.BulkInserterOption{
+		// Default to a stderr-bound INFO logger. The prefect.engine subprocess
+		// pipes its stderr into the Prefect task logs, so this surfaces the
+		// Go-side WARN/INFO lines without any Python plumbing. Callers that
+		// want silence can wrap with WithLogger(log.DiscardLogger) post-hoc,
+		// but the in-binding default is to be loud, since the original
+		// silent default cost us ~4 hours of "is it stuck or is it working?"
+		// debugging on 2026-04-25.
+		contractsapi.WithLogger(kwillog.New(
+			kwillog.WithWriter(os.Stderr),
+			kwillog.WithLevel(kwillog.LevelInfo),
+			kwillog.WithName("bulk_inserter"),
+		)),
+	}
 	if batchSize > 0 {
 		opts = append(opts, contractsapi.WithBatchSize(batchSize))
 	}
@@ -239,6 +273,15 @@ func NewBulkInserter(client *tnclient.Client, batchSize int, maxInflight int, ma
 	}
 	if catchupBackoffSeconds > 0 {
 		opts = append(opts, contractsapi.WithCatchupBackoff(time.Duration(catchupBackoffSeconds)*time.Second))
+	}
+	if catchupMaxAttempts > 0 {
+		opts = append(opts, contractsapi.WithCatchupMaxAttempts(catchupMaxAttempts))
+	}
+	if infraMaxAttempts > 0 {
+		opts = append(opts, contractsapi.WithInfraMaxAttempts(infraMaxAttempts))
+	}
+	if progressLogEveryN > 0 {
+		opts = append(opts, contractsapi.WithProgressLogEveryN(progressLogEveryN))
 	}
 	return client.LoadBulkInserter(opts...)
 }

--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -229,6 +229,9 @@ func InsertRecords(client *tnclient.Client, inputs []types.InsertRecordInput) (s
 //	                      ("no available backend", "connection refused",
 //	                      "no such host"); reuses retryBackoff for sleep
 //	progressLogEveryN     emit INFO progress line every N chunks (0=off)      default 0
+//	                      (overridden to 500 in Python bulk_inserter.py so
+//	                      Prefect bulk loads aren't silent; this layer keeps
+//	                      the conservative Go default)
 //
 // The logger is wired to stderr at INFO level so the prefect.engine
 // subprocess captures BulkInserter WARN lines (catchup/nonce/mempool retries)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -227,7 +227,7 @@ use `BulkInserter` instead of looping `batch_insert_records`. It caches the
 nonce locally and broadcasts each chunk fire-and-forget — admission (~50ms)
 becomes the rate limit instead of inclusion (~1–2s per block).
 
-#### `BulkInserter(client, batch_size=10, max_inflight=200, max_attempts=5, catchup_backoff_seconds=5)`
+#### `BulkInserter(client, batch_size=10, max_inflight=200, max_attempts=15, catchup_backoff_seconds=15, catchup_max_attempts=20, infra_max_attempts=10, progress_log_every_n=500)`
 
 Wraps the sdk-go `BulkInserter` (see
 [`sdk-go/core/contractsapi/bulk_inserter.go`](https://github.com/trufnetwork/sdk-go/blob/main/core/contractsapi/bulk_inserter.go)).
@@ -239,8 +239,11 @@ Mirrors the cached-nonce pattern from `node/extensions/tn_attestation/extension.
 - `client: TNClient` — must use HTTP transport (the default).
 - `batch_size: int = 10` — records per `insert_records` transaction. Must be ≤ the protocol cap (currently 10).
 - `max_inflight: int = 200` — broadcasts queued before draining via `WaitTx`.
-- `max_attempts: int = 5` — initial attempt + retries per chunk on transient errors (`invalid nonce`, `mempool full`, `node is catching up`).
-- `catchup_backoff_seconds: int = 5` — base backoff in seconds when the broadcast backend rejects with `node is catching up`. Actual delay per attempt is `base * (attempt + 1)`, so the default totals ~50 s across 5 attempts. Bump this and/or `max_attempts` if the backend you're hitting is prone to longer catch-up events.
+- `max_attempts: int = 15` — initial attempt + retries per chunk on **non-catchup** transient errors (`invalid nonce`, `mempool full`). With the default 2 s linear backoff, this totals ~3.5 min of wait time per chunk before bubbling up. Sized so a thousand-chunk insert can ride out brief mempool congestion without bottlenecking on outer retry layers.
+- `catchup_backoff_seconds: int = 15` — base backoff in seconds when the broadcast backend rejects with `node is catching up`. Actual delay per attempt is `base * (attempt + 1)`. Combined with `catchup_max_attempts=20`, the loop runs 20 attempts with 19 backoffs (the 20th attempt's failure exits without sleeping), so worst-case wait per chunk is `15+30+...+285s = 2850s ≈ 47.5 min` — comfortably long enough to ride out every catch-up event seen in production.
+- `catchup_max_attempts: int = 20` — initial attempt + retries per chunk on `node is catching up` rejections. **Separate budget from `max_attempts`** because real catch-up events on a public RPC backend (sentry replaying blocks after a peer flap) routinely run minutes long; sharing one budget previously aborted multi-hour bulk loads after just 75 seconds.
+- `infra_max_attempts: int = 10` — initial attempt + retries per chunk on **pre-broadcast** infra errors (KGW `no available backend`, TCP `connection refused`, DNS `no such host`). Safe to retry because the request demonstrably never reached kwild — no risk of duplicate inserts. Reuses the 2 s base linear backoff, so default totals ~90 s wait per chunk before bubbling up. Mid-request errors (EOF, connection reset, context deadline) deliberately stay fatal at the SDK layer to avoid double-broadcast at a bumped nonce; they bubble up to the caller's resume layer instead.
+- `progress_log_every_n: int = 500` — emit an `INFO` log line every N chunks reporting `chunks_done / chunks_total / rows_done / elapsed_sec / chunks_per_sec / eta_sec`. Set to `0` to disable. Logs go to stderr via the Go-side logger (the gopy binding wires a `kwillog` writer to `os.Stderr` at `INFO` level), which subprocess wrappers like Prefect's `prefect.engine` capture into task logs.
 
 #### `inserter.insert_all(batches: List[RecordBatch]) -> List[str]`
 

--- a/examples/bulk_insert_example/README.md
+++ b/examples/bulk_insert_example/README.md
@@ -87,10 +87,17 @@ Total verified: 25 records
       client,
       batch_size=10,                # records per insert_records tx; protocol cap is 10
       max_inflight=500,             # broadcasts queued before forced drain
-      max_attempts=5,               # initial + retries on transient errors
-                                    # (invalid nonce, mempool full, "node is catching up")
-      catchup_backoff_seconds=5,    # base backoff (sec) for "node is catching up";
-                                    # bump for backends prone to longer lag events
+      max_attempts=15,              # initial + retries per chunk on non-catchup transient
+                                    # errors (invalid nonce, mempool full); ~3.5 min wait
+                                    # per chunk before bubbling up
+      catchup_backoff_seconds=15,   # base backoff (sec) for "node is catching up";
+                                    # actual delay = base * (attempt + 1)
+      catchup_max_attempts=20,      # separate budget for catch-up; with 15s base gives
+                                    # ~47.5 min worst-case wait per chunk
+                                    # (20 attempts, 19 backoffs at 15s..285s)
+      infra_max_attempts=10,        # pre-broadcast infra errors only (KGW no-backend,
+                                    # connection refused, DNS); ~90s wait per chunk
+      progress_log_every_n=500,     # emit INFO line every N chunks; 0 disables
   )
   ```
 - **Testnet/mainnet**: change `TEST_PROVIDER_URL` and the private key. Note

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8
-	github.com/trufnetwork/sdk-go v0.6.5-0.20260424050133-2cce51f9dc50
+	github.com/trufnetwork/sdk-go v0.7.1-0.20260428121615-6a692c7bf875
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/trufnetwork/kwil-db v0.10.3-0.20260216231327-01b863886682 h1:Gqee9/lN
 github.com/trufnetwork/kwil-db v0.10.3-0.20260216231327-01b863886682/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8 h1:fzkcURTH5LlSQpKbm5CezXNmJg8SMltcfYhblHY+HZA=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
-github.com/trufnetwork/sdk-go v0.6.5-0.20260424050133-2cce51f9dc50 h1:UMDwDFpIKi4nfyjKOQ8Z9V88xpiVfm5VDcP+IYnbQG8=
-github.com/trufnetwork/sdk-go v0.6.5-0.20260424050133-2cce51f9dc50/go.mod h1:f7IjKRZi4VufWM01b3rODFot1LqopiKw5YR23TL/3dg=
+github.com/trufnetwork/sdk-go v0.7.1-0.20260428121615-6a692c7bf875 h1:HamAvRIBazpSiBTx+v/STVdgg+XXWNKRMzIG5cD6fB8=
+github.com/trufnetwork/sdk-go v0.7.1-0.20260428121615-6a692c7bf875/go.mod h1:f7IjKRZi4VufWM01b3rODFot1LqopiKw5YR23TL/3dg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/src/trufnetwork_sdk_py/bulk_inserter.py
+++ b/src/trufnetwork_sdk_py/bulk_inserter.py
@@ -118,14 +118,15 @@ class BulkInserter:
         which can recover via partial-progress slicing without risking
         duplicate inserts. Reuses the 2s base linear backoff, so default
         gives ~90s wait per chunk before bubbling up.
-    progress_log_every_n : int, default 0 (disabled)
+    progress_log_every_n : int, default 500
         Emit an INFO log line every N chunks reporting chunks done / total,
-        rows done, elapsed time, current chunks/sec rate, and ETA. Highly
-        recommended for any load over ~1000 chunks (~10k rows): without
-        progress logs, the only output between "Submitting N records" and
-        the final result is hours of silence. Logs go to stderr via the
-        Go-side logger, which the prefect.engine subprocess captures into
-        Prefect task logs.
+        rows done, elapsed time, current chunks/sec rate, and ETA. Pass 0
+        to disable. Defaults to 500 here (the underlying Go default is 0)
+        because the Python wrapper is primarily used for hours-long Prefect
+        bulk loads, where without progress logs the only output between
+        "Submitting N records" and the final result is hours of silence.
+        Logs go to stderr via the Go-side logger, which the prefect.engine
+        subprocess captures into Prefect task logs.
     """
 
     def __init__(

--- a/src/trufnetwork_sdk_py/bulk_inserter.py
+++ b/src/trufnetwork_sdk_py/bulk_inserter.py
@@ -84,15 +84,48 @@ class BulkInserter:
         (currently 10).
     max_inflight : int, default 200
         How many broadcasts may queue before draining via WaitTx.
-    max_attempts : int, default 5
-        Max attempts per chunk (initial + retries) on transient errors
-        (invalid nonce, mempool full, "node is catching up").
-    catchup_backoff_seconds : int, default 5
+    max_attempts : int, default 15
+        Max attempts per chunk on non-catchup transient errors (invalid
+        nonce, mempool full). Catch-up errors have their own larger budget
+        — see ``catchup_max_attempts``. Default of 15 is sized so a
+        thousand-chunk insert can ride out brief mempool congestion without
+        bottlenecking on the adapter resume layer above (which only gets 5
+        partial-progress passes); with the default 2s linear backoff that's
+        ~4 minutes of waiting per chunk before bubbling up.
+    catchup_backoff_seconds : int, default 15
         Base backoff in seconds when the broadcast backend rejects with
-        "node is catching up". Actual delay per attempt is base * (attempt + 1)
-        — defaults give a worst-case wait of ~50s across 5 attempts. Bump
-        this and/or ``max_attempts`` if the backend you're hitting is prone
-        to longer catch-up events.
+        "node is catching up". Actual delay per attempt is
+        base * (attempt + 1). With the default of 15s and
+        ``catchup_max_attempts=20`` the loop runs 20 attempts with 19
+        backoffs in between (the 20th attempt's failure exits without
+        sleeping), so the worst-case wait per chunk is
+        ``15 + 30 + … + 285s = 2850s ≈ 47.5 minutes`` — comfortably long
+        enough to ride out every catch-up event seen in production so far
+        without abandoning the whole batch.
+    catchup_max_attempts : int, default 20
+        Max attempts per chunk on "node is catching up" rejections
+        specifically. Separate from ``max_attempts`` because real catch-up
+        events on the public RPC backend (sentry replaying blocks) routinely
+        run minutes long; sharing one budget aborted multi-hour bulk loads
+        after just 75 seconds in the 2026-04-25 incident.
+    infra_max_attempts : int, default 10
+        Max attempts per chunk on **pre-broadcast** infrastructure errors
+        — KGW returning "no available backend", TCP "connection refused",
+        DNS "no such host". These are unambiguously safe to retry because
+        the request demonstrably never reached kwild. Errors that may fire
+        post-admit (EOF, connection reset, context deadline exceeded) stay
+        fatal at the SDK layer and bubble up to the caller's resume layer,
+        which can recover via partial-progress slicing without risking
+        duplicate inserts. Reuses the 2s base linear backoff, so default
+        gives ~90s wait per chunk before bubbling up.
+    progress_log_every_n : int, default 0 (disabled)
+        Emit an INFO log line every N chunks reporting chunks done / total,
+        rows done, elapsed time, current chunks/sec rate, and ETA. Highly
+        recommended for any load over ~1000 chunks (~10k rows): without
+        progress logs, the only output between "Submitting N records" and
+        the final result is hours of silence. Logs go to stderr via the
+        Go-side logger, which the prefect.engine subprocess captures into
+        Prefect task logs.
     """
 
     def __init__(
@@ -100,14 +133,24 @@ class BulkInserter:
         client: TNClient,
         batch_size: int = 10,
         max_inflight: int = 200,
-        max_attempts: int = 5,
-        catchup_backoff_seconds: int = 5,
+        max_attempts: int = 15,
+        catchup_backoff_seconds: int = 15,
+        catchup_max_attempts: int = 20,
+        infra_max_attempts: int = 10,
+        progress_log_every_n: int = 500,
     ):
         if client is None:
             raise ValueError("client is required")
         # Pass 0 for any value to use the Go-side defaults.
         self._inner = truf_sdk.NewBulkInserter(
-            client.client, batch_size, max_inflight, max_attempts, catchup_backoff_seconds
+            client.client,
+            batch_size,
+            max_inflight,
+            max_attempts,
+            catchup_backoff_seconds,
+            catchup_max_attempts,
+            infra_max_attempts,
+            progress_log_every_n,
         )
         self._client = client
 

--- a/tests/fixtures/test_trufnetwork.py
+++ b/tests/fixtures/test_trufnetwork.py
@@ -59,7 +59,22 @@ POSTGRES_CONTAINER = ContainerSpec(
     image=os.environ.get("POSTGRES_IMAGE", "kwildb/postgres:latest"),
     tmpfs_path="/var/lib/postgresql/data",
     env_vars=["POSTGRES_HOST_AUTH_METHOD=trust"],
-    ports={"5432": "5432"}
+    ports={"5432": "5432"},
+    # kwild validates a set of postgres settings at startup
+    # (kwil-db/node/pg/system.go: settingValidations) and exits before the
+    # tn-db container becomes healthy if any are off. We override every
+    # non-default it requires here so we can keep the floating :latest tag
+    # without re-pinning around image regressions. Mirror of the sdk-go
+    # fixture (sdk-go/tests/integration/server_fixture.go); update both
+    # together when kwild's validator changes.
+    args=[
+        "postgres",
+        "-c", "wal_level=logical",
+        "-c", "max_wal_senders=10",
+        "-c", "max_replication_slots=10",
+        "-c", "max_prepared_transactions=200",
+        "-c", "wal_sender_timeout=0",
+    ],
 )
 
 TN_DB_CONTAINER = ContainerSpec(


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3697#issuecomment-4334258361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced BulkInserter with separate retry budgets for different error types (transient, node catch-up, and infrastructure failures).
  * Added configurable progress logging to track chunk processing and throughput.
  * Increased default retry attempts for improved resilience.

* **Documentation**
  * Updated API reference and examples with new configuration parameters and their defaults.
  * Added worst-case delay estimates for catch-up scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->