### PR TITLE
feat: configure streams with zero value accepted

### DIFF
--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -152,7 +152,11 @@ func GenerateStreamId(name string) string {
 }
 
 // DeployStream deploys a stream with the given stream ID and stream type.
-func DeployStream(client *tnclient.Client, streamId string, streamType types.StreamType) (string, error) {
+//
+// The optional allow_zeros flag (default false) controls whether
+// value=0 inserts are persisted on the new stream. Default false
+// preserves the historical behavior — zeros are dropped on insert.
+func DeployStream(client *tnclient.Client, streamId string, streamType types.StreamType, allowZeros bool) (string, error) {
 	ctx := context.Background()
 
 	streamIdTyped, err := util.NewStreamId(streamId)
@@ -160,7 +164,9 @@ func DeployStream(client *tnclient.Client, streamId string, streamType types.Str
 		return "", errors.Wrap(err, "error creating stream id")
 	}
 
-	deployTxHash, err := client.DeployStream(ctx, *streamIdTyped, streamType)
+	deployTxHash, err := client.DeployStreamWithOptions(ctx, *streamIdTyped, streamType, tnclient.DeployStreamOptions{
+		AllowZeros: allowZeros,
+	})
 	if err != nil {
 		return "", errors.Wrap(err, "error deploying stream")
 	}
@@ -842,6 +848,44 @@ func NewVisibilityInput(client *tnclient.Client, streamId string, visibility int
 	return result
 }
 
+// SetAllowZeros toggles whether value=0 inserts are persisted on the
+// stream. Owner-gated. Forward-only — historical state is not rewritten.
+func SetAllowZeros(client *tnclient.Client, streamId string, value bool) (string, error) {
+	ctx := context.Background()
+	stream, err := client.LoadActions()
+	if err != nil {
+		return "", err
+	}
+
+	streamIdObj, err := util.NewStreamId(streamId)
+	if err != nil {
+		return "", err
+	}
+
+	txHash, err := stream.SetAllowZeros(ctx, client.OwnStreamLocator(*streamIdObj), value)
+	if err != nil {
+		return "", err
+	}
+	return txHash.String(), nil
+}
+
+// GetAllowZeros returns the latest allow_zeros setting for the stream.
+// Returns false when no explicit metadata row exists.
+func GetAllowZeros(client *tnclient.Client, streamId string) (bool, error) {
+	ctx := context.Background()
+	stream, err := client.LoadActions()
+	if err != nil {
+		return false, err
+	}
+
+	streamIdObj, err := util.NewStreamId(streamId)
+	if err != nil {
+		return false, err
+	}
+
+	return stream.GetAllowZeros(ctx, client.OwnStreamLocator(*streamIdObj))
+}
+
 // SetReadVisibility sets the read visibility of the stream -- Private or Public
 func SetReadVisibility(client *tnclient.Client, input types.VisibilityInput) (string, error) {
 	ctx := context.Background()
@@ -1095,7 +1139,10 @@ func convertBytesToHex(data []byte) string {
 
 // NewStreamDefinitionForBinding creates a new types.StreamDefinition for binding purposes.
 // It takes string representations of streamId and streamType and converts them.
-func NewStreamDefinitionForBinding(streamIdStr string, streamTypeStr string) (*types.StreamDefinition, error) {
+//
+// allowZeros toggles per-stream persistence of value=0 inserts. Pass
+// false to preserve the historical default (zeros are dropped on insert).
+func NewStreamDefinitionForBinding(streamIdStr string, streamTypeStr string, allowZeros bool) (*types.StreamDefinition, error) {
 	sid, err := util.NewStreamId(streamIdStr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error creating stream id from string: %s", streamIdStr)
@@ -1113,6 +1160,7 @@ func NewStreamDefinitionForBinding(streamIdStr string, streamTypeStr string) (*t
 	return &types.StreamDefinition{
 		StreamId:   *sid,
 		StreamType: st,
+		AllowZeros: allowZeros,
 	}, nil
 }
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -49,12 +49,14 @@ market_index_stream_id = generate_stream_id('market_index')
 >
 > If you're interested in deploying streams, please contact the TRUF.NETWORK team for assistance.
 
-### `client.deploy_stream(stream_id: str, stream_type: str) -> str`
+### `client.deploy_stream(stream_id: str, stream_type: str, wait: bool = True, allow_zeros: bool = False) -> str`
 Deploys a new stream to the TRUF.NETWORK.
 
 #### Parameters
 - `stream_id: str` - Unique stream identifier
 - `stream_type: str` - Stream type (STREAM_TYPE_PRIMITIVE or STREAM_TYPE_COMPOSED)
+- `wait: bool` - Whether to block until the deploy transaction is confirmed (default `True`).
+- `allow_zeros: bool` - Per-stream toggle controlling whether `value=0` inserts are persisted. Default `False` preserves the historical behavior (zeros are silently dropped on insert and excluded from `get_record` results). Set `True` for streams where zero is a meaningful measurement (e.g., a "ships in transit" count that can legitimately be zero). Can be toggled later via `set_allow_zeros`.
 
 #### Returns
 - `str` - Transaction hash of the deployment
@@ -64,7 +66,25 @@ Deploys a new stream to the TRUF.NETWORK.
 from trufnetwork_sdk_py.client import STREAM_TYPE_PRIMITIVE
 
 tx_hash = client.deploy_stream(market_index_stream_id, STREAM_TYPE_PRIMITIVE)
+
+# Stream where zero is a valid value:
+hormuz_stream_id = generate_stream_id("hormuz_ship_count")
+client.deploy_stream(hormuz_stream_id, STREAM_TYPE_PRIMITIVE, allow_zeros=True)
 ```
+
+### `client.set_allow_zeros(stream_id: str, value: bool, wait: bool = True) -> str`
+Toggle the per-stream `allow_zeros` flag for an existing stream. Owner-gated.
+
+The flip is forward-only — historical inserts are not rewritten. Zero records that were dropped before the flip stay dropped; zeros that arrive after the flip persist.
+
+#### Example
+```python
+client.set_allow_zeros(stream_id, True)  # opt in
+client.set_allow_zeros(stream_id, False) # opt back out
+```
+
+### `client.get_allow_zeros(stream_id: str) -> bool`
+Returns the current `allow_zeros` setting for the given stream. Returns `False` when the stream has no explicit metadata row, matching the implicit default applied at insert time.
 
 ## Stream Destruction
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -49,12 +49,12 @@ market_index_stream_id = generate_stream_id('market_index')
 >
 > If you're interested in deploying streams, please contact the TRUF.NETWORK team for assistance.
 
-### `client.deploy_stream(stream_id: str, stream_type: str, wait: bool = True, allow_zeros: bool = False) -> str`
+### `client.deploy_stream(stream_id: str, stream_type: str = truf_sdk.StreamTypePrimitive, wait: bool = True, allow_zeros: bool = False) -> str`
 Deploys a new stream to the TRUF.NETWORK.
 
 #### Parameters
 - `stream_id: str` - Unique stream identifier
-- `stream_type: str` - Stream type (STREAM_TYPE_PRIMITIVE or STREAM_TYPE_COMPOSED)
+- `stream_type: str` - Stream type (`STREAM_TYPE_PRIMITIVE` or `STREAM_TYPE_COMPOSED`). Defaults to `truf_sdk.StreamTypePrimitive`, so primitive-stream callers can omit it (e.g., `client.deploy_stream(stream_id)`).
 - `wait: bool` - Whether to block until the deploy transaction is confirmed (default `True`).
 - `allow_zeros: bool` - Per-stream toggle controlling whether `value=0` inserts are persisted. Default `False` preserves the historical behavior (zeros are silently dropped on insert and excluded from `get_records` results). Set `True` for streams where zero is a meaningful measurement (e.g., a "ships in transit" count that can legitimately be zero). Can be toggled later via `set_allow_zeros`.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -56,7 +56,7 @@ Deploys a new stream to the TRUF.NETWORK.
 - `stream_id: str` - Unique stream identifier
 - `stream_type: str` - Stream type (STREAM_TYPE_PRIMITIVE or STREAM_TYPE_COMPOSED)
 - `wait: bool` - Whether to block until the deploy transaction is confirmed (default `True`).
-- `allow_zeros: bool` - Per-stream toggle controlling whether `value=0` inserts are persisted. Default `False` preserves the historical behavior (zeros are silently dropped on insert and excluded from `get_record` results). Set `True` for streams where zero is a meaningful measurement (e.g., a "ships in transit" count that can legitimately be zero). Can be toggled later via `set_allow_zeros`.
+- `allow_zeros: bool` - Per-stream toggle controlling whether `value=0` inserts are persisted. Default `False` preserves the historical behavior (zeros are silently dropped on insert and excluded from `get_records` results). Set `True` for streams where zero is a meaningful measurement (e.g., a "ships in transit" count that can legitimately be zero). Can be toggled later via `set_allow_zeros`.
 
 #### Returns
 - `str` - Transaction hash of the deployment

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8
-	github.com/trufnetwork/sdk-go v0.7.1-0.20260428121615-6a692c7bf875
+	github.com/trufnetwork/sdk-go v0.7.1-0.20260430091556-edc0cff98b19
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/trufnetwork/kwil-db v0.10.3-0.20260216231327-01b863886682 h1:Gqee9/lN
 github.com/trufnetwork/kwil-db v0.10.3-0.20260216231327-01b863886682/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8 h1:fzkcURTH5LlSQpKbm5CezXNmJg8SMltcfYhblHY+HZA=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260414113323-696cc38f53b8/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
-github.com/trufnetwork/sdk-go v0.7.1-0.20260428121615-6a692c7bf875 h1:HamAvRIBazpSiBTx+v/STVdgg+XXWNKRMzIG5cD6fB8=
-github.com/trufnetwork/sdk-go v0.7.1-0.20260428121615-6a692c7bf875/go.mod h1:f7IjKRZi4VufWM01b3rODFot1LqopiKw5YR23TL/3dg=
+github.com/trufnetwork/sdk-go v0.7.1-0.20260430091556-edc0cff98b19 h1:D7SCHxBiaFcx7+1mRJTNBMFtwzT2q6pXvV56fdSAYqU=
+github.com/trufnetwork/sdk-go v0.7.1-0.20260430091556-edc0cff98b19/go.mod h1:f7IjKRZi4VufWM01b3rODFot1LqopiKw5YR23TL/3dg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -29,7 +29,7 @@ import warnings
 import trufnetwork_sdk_c_bindings.exports as truf_sdk
 import trufnetwork_sdk_c_bindings.go as go
 
-from typing import Any, TypedDict, Literal, cast, overload, Generic, TypeVar, Optional
+from typing import Any, TypedDict, Literal, cast, overload, Generic, TypeVar, Optional, Required
 
 from pydantic import BaseModel
 
@@ -55,9 +55,13 @@ class RecordBatch(TypedDict):
     inputs: list[Record]
 
 
-class StreamDefinitionInput(TypedDict):
-    stream_id: str
-    stream_type: Literal["primitive", "composed"]
+class StreamDefinitionInput(TypedDict, total=False):
+    stream_id: Required[str]
+    stream_type: Required[Literal["primitive", "composed"]]
+    # allow_zeros (default False) toggles per-stream persistence of
+    # value=0 inserts. Marked optional via total=False so existing
+    # callers that only set stream_id/stream_type continue to work.
+    allow_zeros: bool
 
 
 class StreamLocatorInput(TypedDict):
@@ -624,16 +628,56 @@ class TNClient:
             stream_id: str,
             stream_type: str = truf_sdk.StreamTypePrimitive,
             wait: bool = True,
+            allow_zeros: bool = False,
     ) -> str:
         """
         Deploy a stream with the given stream ID and stream type.
         If wait is True, it will wait for the transaction to be confirmed.
         Returns the transaction hash.
+
+        Parameters:
+            stream_id: 32-character stream identifier (use generate_stream_id).
+            stream_type: STREAM_TYPE_PRIMITIVE or STREAM_TYPE_COMPOSED.
+            wait: Block until the deploy transaction is confirmed.
+            allow_zeros: Default False (preserves the historical behavior
+                of dropping value=0 inserts). Set True for streams where
+                zero is a meaningful measurement (e.g., a "ships in transit"
+                count that can legitimately be zero). Can be toggled later
+                with `set_allow_zeros`.
         """
-        deploy_tx_hash = truf_sdk.DeployStream(self.client, stream_id, stream_type)
+        deploy_tx_hash = truf_sdk.DeployStream(self.client, stream_id, stream_type, allow_zeros)
         if wait:
             self.wait_for_tx(deploy_tx_hash)
         return deploy_tx_hash
+
+    def set_allow_zeros(
+            self,
+            stream_id: str,
+            value: bool,
+            wait: bool = True,
+    ) -> str:
+        """
+        Toggle the per-stream allow_zeros flag for an existing stream.
+
+        Owner-gated. The toggle is forward-only — historical inserts are
+        not rewritten. Zeros that were dropped before the flip stay
+        dropped; zeros that arrive after the flip persist.
+
+        Returns the transaction hash.
+        """
+        tx_hash = truf_sdk.SetAllowZeros(self.client, stream_id, value)
+        if wait:
+            self.wait_for_tx(tx_hash)
+        return tx_hash
+
+    def get_allow_zeros(self, stream_id: str) -> bool:
+        """
+        Returns the current allow_zeros setting for the given stream.
+
+        Returns False if the stream has no explicit metadata row, which
+        matches the implicit default applied at insert time.
+        """
+        return truf_sdk.GetAllowZeros(self.client, stream_id)
 
     def insert_record(
             self, stream_id: str, record: dict[str, float | int], wait: bool = True
@@ -1274,11 +1318,14 @@ class TNClient:
         If wait is True, it will wait for the transaction to be confirmed.
         Returns the transaction hash of the batch operation.
         """
-        # Build a list of Go StreamDefinition objects
+        # Build a list of Go StreamDefinition objects.
+        # allow_zeros defaults to False (today's drop-zeros behavior).
         go_definitions = []
         for def_input in definitions:
             go_def = truf_sdk.NewStreamDefinitionForBinding(
-                def_input["stream_id"], def_input["stream_type"]
+                def_input["stream_id"],
+                def_input["stream_type"],
+                bool(def_input.get("allow_zeros", False)),
             )
             go_definitions.append(go_def)
 

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -1320,12 +1320,22 @@ class TNClient:
         """
         # Build a list of Go StreamDefinition objects.
         # allow_zeros defaults to False (today's drop-zeros behavior).
+        # The TypedDict declares allow_zeros: bool, but TypedDicts are not
+        # enforced at runtime — Python's bool("false") returns True, so a
+        # plain bool() coercion would silently invert the user's intent.
+        # Reject non-bool values up front to surface the bug instead.
         go_definitions = []
-        for def_input in definitions:
+        for idx, def_input in enumerate(definitions):
+            allow_zeros = def_input.get("allow_zeros", False)
+            if not isinstance(allow_zeros, bool):
+                raise TypeError(
+                    f"definitions[{idx}].allow_zeros must be bool, "
+                    f"got {type(allow_zeros).__name__}={allow_zeros!r}"
+                )
             go_def = truf_sdk.NewStreamDefinitionForBinding(
                 def_input["stream_id"],
                 def_input["stream_type"],
-                bool(def_input.get("allow_zeros", False)),
+                allow_zeros,
             )
             go_definitions.append(go_def)
 

--- a/tests/test_allow_zeros.py
+++ b/tests/test_allow_zeros.py
@@ -1,0 +1,167 @@
+"""Tests for the per-stream allow_zeros configuration.
+
+Mirrors the behaviors covered upstream in
+node/tests/streams/allow_zeros_test.go from the SDK consumer perspective:
+the deploy-time opt-in, the post-deploy toggle, and the owner gate on
+set_allow_zeros.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from trufnetwork_sdk_py.client import TNClient
+from trufnetwork_sdk_py.utils import generate_stream_id
+from tests.fixtures.test_trufnetwork import tn_node, DB_PRIVATE_KEY
+
+
+OWNER_PRIVATE_KEY = "0121234567890123456789012345678901234567890123456789012345178901"
+
+
+@pytest.fixture(scope="module")
+def owner_client(tn_node, grant_network_writer):
+    client = TNClient(tn_node, OWNER_PRIVATE_KEY)
+    grant_network_writer(client)
+    return client
+
+
+@pytest.fixture(scope="module")
+def non_owner_client(tn_node):
+    # DB_PRIVATE_KEY is a separate signer; no network_writer grant required
+    # because set_allow_zeros only needs a transaction (and the owner check
+    # runs inside the action itself, which is exactly what we want to assert).
+    return TNClient(tn_node, DB_PRIVATE_KEY)
+
+
+def _ts(date_str: str) -> int:
+    return int(
+        datetime.strptime(date_str, "%Y-%m-%d")
+        .replace(tzinfo=timezone.utc)
+        .timestamp()
+    )
+
+
+def _safe_destroy(client: TNClient, stream_id: str) -> None:
+    try:
+        client.destroy_stream(stream_id)
+    except Exception:
+        pass
+
+
+def test_default_drops_zero_inserts(owner_client: TNClient):
+    """Without allow_zeros, value=0 is silently dropped on insert."""
+    stream_id = generate_stream_id("allow_zeros_default_drop")
+    _safe_destroy(owner_client, stream_id)
+
+    owner_client.deploy_stream(stream_id)
+    try:
+        assert owner_client.get_allow_zeros(stream_id) is False
+
+        owner_client.insert_record(
+            stream_id, {"date": _ts("2024-01-01"), "value": 0}
+        )
+        owner_client.insert_record(
+            stream_id, {"date": _ts("2024-01-02"), "value": 5}
+        )
+
+        records = owner_client.get_records(
+            stream_id,
+            date_from=_ts("2024-01-01"),
+            date_to=_ts("2024-01-02"),
+            use_cache=False,
+        ).data
+
+        event_times = {r["EventTime"] for r in records}
+        assert str(_ts("2024-01-01")) not in event_times, (
+            "zero value must be dropped under default allow_zeros=False"
+        )
+        assert str(_ts("2024-01-02")) in event_times
+    finally:
+        _safe_destroy(owner_client, stream_id)
+
+
+def test_allow_zeros_true_at_deploy_persists_zero(owner_client: TNClient):
+    """deploy_stream(allow_zeros=True) opts the stream out of the zero filter."""
+    stream_id = generate_stream_id("allow_zeros_deploy_true")
+    _safe_destroy(owner_client, stream_id)
+
+    owner_client.deploy_stream(stream_id, allow_zeros=True)
+    try:
+        assert owner_client.get_allow_zeros(stream_id) is True
+
+        owner_client.insert_record(
+            stream_id, {"date": _ts("2024-02-01"), "value": 0}
+        )
+
+        records = owner_client.get_records(
+            stream_id,
+            date_from=_ts("2024-02-01"),
+            date_to=_ts("2024-02-01"),
+            use_cache=False,
+        ).data
+
+        assert len(records) == 1, "zero record must persist when allow_zeros=True"
+        assert float(records[0]["Value"]) == 0.0
+    finally:
+        _safe_destroy(owner_client, stream_id)
+
+
+def test_set_allow_zeros_toggle_is_forward_only(owner_client: TNClient):
+    """Flipping allow_zeros affects future inserts only; pre-flip drops stay dropped."""
+    stream_id = generate_stream_id("allow_zeros_toggle")
+    _safe_destroy(owner_client, stream_id)
+
+    owner_client.deploy_stream(stream_id)
+    try:
+        # Pre-flip: zero is dropped
+        owner_client.insert_record(
+            stream_id, {"date": _ts("2024-03-01"), "value": 0}
+        )
+
+        # Flip on
+        owner_client.set_allow_zeros(stream_id, True)
+        assert owner_client.get_allow_zeros(stream_id) is True
+
+        # Post-flip: zero persists
+        owner_client.insert_record(
+            stream_id, {"date": _ts("2024-03-02"), "value": 0}
+        )
+
+        records = owner_client.get_records(
+            stream_id,
+            date_from=_ts("2024-03-01"),
+            date_to=_ts("2024-03-02"),
+            use_cache=False,
+        ).data
+        event_times = {r["EventTime"] for r in records}
+
+        assert str(_ts("2024-03-01")) not in event_times, (
+            "pre-flip zero must remain dropped (forward-only semantics)"
+        )
+        assert str(_ts("2024-03-02")) in event_times, (
+            "post-flip zero must persist"
+        )
+
+        # Flip back off and confirm the read reflects it
+        owner_client.set_allow_zeros(stream_id, False)
+        assert owner_client.get_allow_zeros(stream_id) is False
+    finally:
+        _safe_destroy(owner_client, stream_id)
+
+
+def test_non_owner_cannot_toggle_allow_zeros(
+    owner_client: TNClient, non_owner_client: TNClient
+):
+    """The owner gate on set_allow_zeros rejects non-owners."""
+    stream_id = generate_stream_id("allow_zeros_owner_gate")
+    _safe_destroy(owner_client, stream_id)
+
+    owner_client.deploy_stream(stream_id)
+    try:
+        with pytest.raises(Exception):
+            non_owner_client.set_allow_zeros(stream_id, True)
+
+        # Owner-side state unchanged.
+        assert owner_client.get_allow_zeros(stream_id) is False
+    finally:
+        _safe_destroy(owner_client, stream_id)

--- a/tests/test_allow_zeros.py
+++ b/tests/test_allow_zeros.py
@@ -42,10 +42,23 @@ def _ts(date_str: str) -> int:
 
 
 def _safe_destroy(client: TNClient, stream_id: str) -> None:
+    """Best-effort cleanup that tolerates a missing stream but re-raises
+    anything else so genuine destroy failures don't quietly mask test bugs.
+
+    The Go binding raises a generic exception with a message like
+    "stream does not exist" when the row isn't there. Match the message
+    rather than the type because the C-extension exception class isn't
+    stable across builds.
+    """
     try:
         client.destroy_stream(stream_id)
-    except Exception:
-        pass
+    except Exception as e:
+        msg = str(e).lower()
+        if "does not exist" in msg or "not found" in msg or "stream not exist" in msg:
+            return
+        raise AssertionError(
+            f"_safe_destroy({stream_id!r}) failed unexpectedly: {e!r}"
+        ) from e
 
 
 def test_default_drops_zero_inserts(owner_client: TNClient):
@@ -158,7 +171,17 @@ def test_non_owner_cannot_toggle_allow_zeros(
 
     owner_client.deploy_stream(stream_id)
     try:
-        with pytest.raises(Exception):
+        # The SDK's set_allow_zeros always sends the caller's address as
+        # the data_provider (OwnStreamLocator in the binding). When a
+        # non-owner calls it, the lookup `(data_provider=non_owner, stream_id)`
+        # finds nothing and `is_stream_owner` raises "Stream does not exist"
+        # before set_allow_zeros's own owner-gate ERROR fires. Either error
+        # is a correct rejection, so match on both phrases — the test fails
+        # only if the toggle actually succeeds or a different failure occurs.
+        with pytest.raises(
+            Exception,
+            match="(?:Stream does not exist|Only stream owner can set allow_zeros)",
+        ):
             non_owner_client.set_allow_zeros(stream_id, True)
 
         # Owner-side state unchanged.


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3757

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-stream allow_zeros flag to control persistence of zero-value data points (defaults to disabled).
  * Added methods to set and get the per-stream allow_zeros flag; setting is forward-only (historical drops unaffected).

* **Documentation**
  * API reference updated with allow_zeros and wait parameters and examples.

* **Tests**
  * New tests validating allow_zeros behavior, toggling semantics, and owner-gate restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->