### PR TITLE
fix: prevent SIGSEGV crash on Homebrew

### DIFF
--- a/.github/workflows/distribution-test.yml
+++ b/.github/workflows/distribution-test.yml
@@ -21,14 +21,11 @@ jobs:
             -e TN_ENDPOINT="https://gateway.mainnet.truf.network" \
             sdk-py-dist-test
 
-  test-native-build:
-    name: Test Native Build on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-
+  # Linux dev-install path: builds via setup.py + setup-python, mirrors
+  # what a contributor would run locally with `uv pip install -e .`.
+  test-native-build-linux:
+    name: Test Native Build (Linux)
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,10 +40,8 @@ jobs:
           go install github.com/go-python/gopy@v0.4.10
           go install golang.org/x/tools/cmd/goimports@latest
           echo "$HOME/go/bin" >> $GITHUB_PATH
-        shell: bash
 
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
+      - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential patchelf
@@ -55,11 +50,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.12'
-      
+
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
-      - name: Build and Test Natively
+      - name: Build and test natively
         run: |
           export PATH="$HOME/.local/bin:$PATH"
           uv pip install setuptools wheel pybindgen build --system
@@ -67,4 +62,45 @@ jobs:
           python -m build --wheel --outdir /tmp/wheelhouse
           uv pip install /tmp/wheelhouse/*.whl --system
           python tests/distribution/get_account_test.py
-        shell: bash
+
+  # macOS PR check uses the same cibuildwheel pipeline as the release
+  # workflow so the wheel under test is structurally identical to what
+  # ships, then loads it under a Homebrew Python to assert
+  # cross-interpreter portability — the property the v0.6.6 SIGSEGV
+  # report showed was missing.
+  test-native-build-macos:
+    name: Test Native Build (macOS arm64)
+    runs-on: macos-14
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24.1'
+
+      - name: Build wheels with cibuildwheel
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_BUILD: cp312-macosx_arm64
+          CIBW_ARCHS_MACOS: arm64
+          CIBW_ENVIRONMENT: >
+            CGO_ENABLED=1
+            GOARCH=arm64
+            PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+            MACOSX_DEPLOYMENT_TARGET=11.0
+          CIBW_BEFORE_ALL_MACOS: |
+            go install github.com/go-python/gopy@v0.4.10
+            go install golang.org/x/tools/cmd/goimports@latest
+          CIBW_BEFORE_BUILD_MACOS: |
+            pip install pybindgen setuptools wheel setuptools-scm
+
+      - name: Verify wheel under Homebrew Python
+        run: |
+          brew install python@3.12
+          BREW_PY=$(brew --prefix python@3.12)/bin/python3.12
+          "$BREW_PY" --version
+          "$BREW_PY" -m venv /tmp/brew-venv
+          /tmp/brew-venv/bin/pip install wheelhouse/*.whl
+          /tmp/brew-venv/bin/python tests/distribution/get_account_test.py

--- a/.github/workflows/distribution-test.yml
+++ b/.github/workflows/distribution-test.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.24.1'
 
@@ -47,7 +47,7 @@ jobs:
           sudo apt-get install -y build-essential patchelf
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.24.1'
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -11,19 +11,13 @@ on:
 permissions: write-all
 
 jobs:
-  build:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.12']
-
+  build-linux:
+    name: Build Linux wheels
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetch all history for setuptools_scm to detect version from git tags
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v4
@@ -37,41 +31,89 @@ jobs:
           echo "$HOME/go/bin" >> $GITHUB_PATH
         shell: bash
 
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
+      - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:.
+          sudo apt-get install -y build-essential patchelf
 
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
 
       - name: Install build tools
-        run: |
-          python3 -m pip install --upgrade pip setuptools wheel pybindgen build setuptools-scm
+        run: python3 -m pip install --upgrade pip setuptools wheel pybindgen build setuptools-scm
 
       - name: Build gopy bindings
         run: make gopy_build
-        shell: bash
 
       - name: Build wheels
         run: python -m build --wheel --outdir wheelhouse
 
-      - name: Upload wheels as artifacts
+      - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-linux
+          path: wheelhouse/*.whl
+
+  build-macos:
+    name: Build macOS wheels (${{ matrix.arch }})
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runs-on: macos-14
+            goarch: arm64
+          # Uncomment to also publish x86_64 wheels:
+          # - arch: x86_64
+          #   runs-on: macos-13
+          #   goarch: amd64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24.1'
+
+      # cibuildwheel uses the python.org installer for the in-wheel Python,
+      # which bakes @rpath-relative libpython install names into the .so —
+      # the property that makes the wheel loadable by Homebrew/conda/uv
+      # interpreters.
+      - name: Build wheels with cibuildwheel
+        uses: pypa/cibuildwheel@v2.21.3
+        env:
+          CIBW_BUILD: cp312-macosx_${{ matrix.arch }}
+          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+          # CGO must be on for arm64; gopy + goimports must be reachable
+          # inside the build's hermetic env, so we install them in
+          # BEFORE_ALL and forward PATH via CIBW_ENVIRONMENT.
+          CIBW_ENVIRONMENT: >
+            CGO_ENABLED=1
+            GOARCH=${{ matrix.goarch }}
+            PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
+            MACOSX_DEPLOYMENT_TARGET=11.0
+          CIBW_BEFORE_ALL_MACOS: |
+            go install github.com/go-python/gopy@v0.4.10
+            go install golang.org/x/tools/cmd/goimports@latest
+          CIBW_BEFORE_BUILD_MACOS: |
+            pip install pybindgen setuptools wheel setuptools-scm
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.arch }}
           path: wheelhouse/*.whl
 
   publish:
-    name: Publish Wheels to Release
-    needs: build
+    name: Publish wheels to release
+    needs: [build-linux, build-macos]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-
     steps:
       - name: Download all built wheels
         uses: actions/download-artifact@v4
@@ -80,7 +122,7 @@ jobs:
           merge-multiple: true
           path: dist/
 
-      - name: Publish GitHub Release with Wheels
+      - name: Publish GitHub release with wheels
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*.whl

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,7 +8,8 @@ on:
   # Also allow manual re-runs
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  contents: write
 
 jobs:
   build-linux:
@@ -20,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.24.1'
 
@@ -37,7 +38,7 @@ jobs:
           sudo apt-get install -y build-essential patchelf
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -76,7 +77,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.24.1'
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -104,6 +104,21 @@ jobs:
           CIBW_BEFORE_BUILD_MACOS: |
             pip install pybindgen setuptools wheel setuptools-scm
 
+      # Smoke-test the wheel before publishing: install it into a fresh
+      # interpreter and load the C bindings. Catches packaging breakage
+      # and the SIGSEGV-class regression the PR fixes (the import alone
+      # triggers loading both gopy .so files).
+      - name: Set up Python for wheel smoke test
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Smoke-test built wheel
+        run: |
+          python -m venv /tmp/smoke-venv
+          /tmp/smoke-venv/bin/pip install wheelhouse/*.whl
+          /tmp/smoke-venv/bin/python -c "from trufnetwork_sdk_py.client import TNClient; print('wheel import ok')"
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,17 @@ gopy_build:
 	if [ `uname` = "Linux" ]; then \
 		patchelf --set-rpath '$$ORIGIN' src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so; \
 	elif [ `uname` = "Darwin" ]; then \
-		install_name_tool -add_rpath @loader_path src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so; \
+		install_name_tool -id @loader_path/trufnetwork_sdk_c_bindings_go.so \
+			src/trufnetwork_sdk_c_bindings/trufnetwork_sdk_c_bindings_go.so; \
+		GO_SO_OLD=`otool -L src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so | awk '/trufnetwork_sdk_c_bindings_go\.so/ {print $$1; exit}'`; \
+		if [ -z "$$GO_SO_OLD" ]; then \
+			echo "FATAL: _trufnetwork_sdk_c_bindings.so does not reference trufnetwork_sdk_c_bindings_go.so"; exit 1; \
+		fi; \
+		install_name_tool -change "$$GO_SO_OLD" @loader_path/trufnetwork_sdk_c_bindings_go.so \
+			src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so; \
+		install_name_tool -add_rpath @loader_path \
+			src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so; \
+		echo "=== otool -L (post-fix) ==="; \
+		otool -L src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so; \
+		otool -L src/trufnetwork_sdk_c_bindings/trufnetwork_sdk_c_bindings_go.so; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
+UNAME_S := $(shell uname)
+
+# On macOS, link the Go .so dynamically against libpython so Python symbols
+# resolve at load time against whatever interpreter imports the module
+# (Homebrew/conda/uv/python.org), instead of baking in an absolute path to
+# the build-time libpython. The resulting #cgo LDFLAGS contain
+# `-undefined dynamic_lookup`, which cgo blocks by default, so widen the
+# allow regex for this build.
+ifeq ($(UNAME_S),Darwin)
+DYNAMIC_LINK_FLAG := -dynamic-link=true
+export CGO_LDFLAGS_ALLOW := .*
+endif
+
 gopy_build:
 	rm -f src/trufnetwork_sdk_c_bindings/*.so
-	gopy gen -output=src/trufnetwork_sdk_c_bindings -vm=python3 -name=trufnetwork_sdk_c_bindings -dynamic-link=true ./bindings
+	gopy gen -output=src/trufnetwork_sdk_c_bindings -vm=python3 -name=trufnetwork_sdk_c_bindings $(DYNAMIC_LINK_FLAG) ./bindings
 	cd src/trufnetwork_sdk_c_bindings && \
 	make build
 	if [ `uname` = "Linux" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 gopy_build:
 	rm -f src/trufnetwork_sdk_c_bindings/*.so
-	gopy gen -output=src/trufnetwork_sdk_c_bindings -vm=python3 -name=trufnetwork_sdk_c_bindings ./bindings
+	gopy gen -output=src/trufnetwork_sdk_c_bindings -vm=python3 -name=trufnetwork_sdk_c_bindings -dynamic-link=true ./bindings
 	cd src/trufnetwork_sdk_c_bindings && \
 	make build
 	if [ `uname` = "Linux" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,11 @@ gopy_build:
 		echo "=== otool -L (post-fix) ==="; \
 		otool -L src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so; \
 		otool -L src/trufnetwork_sdk_c_bindings/trufnetwork_sdk_c_bindings_go.so; \
+		for f in src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so \
+		         src/trufnetwork_sdk_c_bindings/trufnetwork_sdk_c_bindings_go.so; do \
+			if otool -L "$$f" | grep -E 'Python\.framework|libpython' >/dev/null; then \
+				echo "FATAL: $$f still references Python (Python.framework or libpython). This will SIGSEGV under non-build-time Python interpreters (Homebrew/conda/uv). Verify -dynamic-link=true and the LDFLAGS sub-make override are taking effect."; \
+				exit 1; \
+			fi; \
+		done; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,31 @@
 UNAME_S := $(shell uname)
 
-# On macOS, link the Go .so dynamically against libpython so Python symbols
-# resolve at load time against whatever interpreter imports the module
-# (Homebrew/conda/uv/python.org), instead of baking in an absolute path to
-# the build-time libpython. The resulting #cgo LDFLAGS contain
-# `-undefined dynamic_lookup`, which cgo blocks by default, so widen the
-# allow regex for this build.
+# On macOS, decouple both gopy artifacts from a specific libpython:
+#   * `-dynamic-link=true` switches the #cgo LDFLAGS in the generated .go
+#     file from `-L... -lpython3.12` to LDSHARED-derived flags
+#     (`-undefined dynamic_lookup`), so the Go .so defers Python symbols
+#     to whoever loads it.
+#   * Overriding LDFLAGS for the gopy-emitted sub-make does the same for
+#     the gcc step that links the Python C extension wrapper
+#     (`_trufnetwork_sdk_c_bindings.so`); otherwise gopy hard-codes
+#     `pycfg.LdFlags` regardless of `-dynamic-link`, leaving the wrapper
+#     bound to the build-time libpython and triggering the Homebrew
+#     SIGSEGV the PR is meant to prevent.
+# `-undefined dynamic_lookup` is on cgo's denylist, so widen the allow
+# regex too.
 ifeq ($(UNAME_S),Darwin)
 DYNAMIC_LINK_FLAG := -dynamic-link=true
 export CGO_LDFLAGS_ALLOW := .*
+SUBMAKE_BUILD := LDFLAGS="-undefined dynamic_lookup -Wl,-flat_namespace" make build
+else
+SUBMAKE_BUILD := make build
 endif
 
 gopy_build:
 	rm -f src/trufnetwork_sdk_c_bindings/*.so
 	gopy gen -output=src/trufnetwork_sdk_c_bindings -vm=python3 -name=trufnetwork_sdk_c_bindings $(DYNAMIC_LINK_FLAG) ./bindings
 	cd src/trufnetwork_sdk_c_bindings && \
-	make build
+	$(SUBMAKE_BUILD)
 	if [ `uname` = "Linux" ]; then \
 		patchelf --set-rpath '$$ORIGIN' src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so; \
 	elif [ `uname` = "Darwin" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,12 @@ UNAME_S := $(shell uname)
 ifeq ($(UNAME_S),Darwin)
 DYNAMIC_LINK_FLAG := -dynamic-link=true
 export CGO_LDFLAGS_ALLOW := .*
-SUBMAKE_BUILD := LDFLAGS="-undefined dynamic_lookup -Wl,-flat_namespace" make build
+# IMPORTANT: pass LDFLAGS as a make command-line argument, not as an env
+# var prefix. The gopy-emitted Makefile defines `LDFLAGS = ...` itself,
+# and Make precedence gives Makefile assignments priority over env vars
+# (command-line args win over both). `LDFLAGS=... make build` would be
+# silently ignored.
+SUBMAKE_BUILD := make build LDFLAGS="-undefined dynamic_lookup -Wl,-flat_namespace"
 else
 SUBMAKE_BUILD := make build
 endif

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ gopy_build:
 	if [ `uname` = "Linux" ]; then \
 		patchelf --set-rpath '$$ORIGIN' src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so; \
 	elif [ `uname` = "Darwin" ]; then \
+		set -e; \
 		install_name_tool -id @loader_path/trufnetwork_sdk_c_bindings_go.so \
 			src/trufnetwork_sdk_c_bindings/trufnetwork_sdk_c_bindings_go.so; \
 		GO_SO_OLD=`otool -L src/trufnetwork_sdk_c_bindings/_trufnetwork_sdk_c_bindings.so | awk '/trufnetwork_sdk_c_bindings_go\.so/ {print $$1; exit}'`; \


### PR DESCRIPTION
resolves: https://github.com/truflation/augustus/issues/2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split build and test pipelines into separate Linux and macOS workflows so artifacts are built and validated per-OS, and release publishing waits for both builds.
  * Strengthened native build behavior on macOS to use dynamic linking, repair library references and rpaths, and validate resulting packages to improve compatibility of distributed wheels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->