### PR TITLE
fix: enable native Windows source builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,24 @@ else
 SUBMAKE_BUILD := make build
 endif
 
+# gopy's own template emits a Windows-only line to fix pybindgen's PyInit_
+# declaration (see the "windows-only sed hack" comment it generates), but
+# indents that one recipe line with two spaces instead of a tab, which GNU
+# Make rejects as "missing separator" before it ever reaches a shell. This
+# is gopy's bug, not ours: the line either doesn't exist (Linux/macOS
+# targets never emit it) or is well-formed once fixed upstream, so the
+# check below is content-matched and OS-gated to stay a no-op everywhere
+# except an affected Windows build.
+ifeq ($(OS),Windows_NT)
+WINGOPY_PYINIT_FIX := sed -i 's|^  sed -i "s/ PyInit_/|\tsed -i "s/ PyInit_/|' src/trufnetwork_sdk_c_bindings/Makefile
+else
+WINGOPY_PYINIT_FIX := true
+endif
+
 gopy_build:
 	rm -f src/trufnetwork_sdk_c_bindings/*.so
 	gopy gen -output=src/trufnetwork_sdk_c_bindings -vm=python3 -name=trufnetwork_sdk_c_bindings $(DYNAMIC_LINK_FLAG) ./bindings
+	@$(WINGOPY_PYINIT_FIX)
 	cd src/trufnetwork_sdk_c_bindings && \
 	$(SUBMAKE_BUILD)
 	if [ `uname` = "Linux" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ WINGOPY_PYINIT_FIX := true
 endif
 
 gopy_build:
-	rm -f src/trufnetwork_sdk_c_bindings/*.so
+	rm -f src/trufnetwork_sdk_c_bindings/*.so src/trufnetwork_sdk_c_bindings/*.pyd src/trufnetwork_sdk_c_bindings/*.dll
 	gopy gen -output=src/trufnetwork_sdk_c_bindings -vm=python3 -name=trufnetwork_sdk_c_bindings $(DYNAMIC_LINK_FLAG) ./bindings
 	@$(WINGOPY_PYINIT_FIX)
 	cd src/trufnetwork_sdk_c_bindings && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
 [tool.setuptools]
 packages = { find = { where = ["src"] } }
 include-package-data = true
-package-data = { "*" = ["*.so", "*.dll", "*.dylib"] }
+package-data = { "*" = ["*.so", "*.dll", "*.dylib", "*.pyd"] }
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
setup.py's check_dependencies() shells out to `which`, so a working build already required Go, MinGW-w64 gcc, MSYS2 make, and gopy on PATH. Once those are present, two remaining bugs still block a native Windows source install:

- gopy's own generated Makefile indents its Windows-only PyInit_ sed fix-up with two spaces instead of a tab, which GNU Make rejects as "missing separator" before it reaches a shell. Patch it in place right after `gopy gen` runs. The check is content-matched (not line-numbered) and gated on `$(OS) == Windows_NT`, so it's a `true` no-op on Linux/macOS, where gopy doesn't emit that line at all.
- pyproject.toml's package-data glob only listed *.so/*.dll/*.dylib, so the compiled extension gopy produces as *.pyd on Windows was silently dropped from the wheel. Adding *.pyd is purely additive.

Verified end-to-end on Windows: `make gopy_build` produces working .pyd artifacts, `pip install --no-build-isolation` builds a wheel that actually contains them, and the installed SDK successfully signs and submits a real testnet transaction.

This does not change the Linux or macOS build/install path in any way — both branches above resolve to their prior behavior on those platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows build compatibility by correcting generated build instructions automatically.
  * Fixed packaging to include compiled Python extension files on supported platforms.

* **Compatibility**
  * Added support for distributing binary extensions with Windows, macOS, and Python-specific filename suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->