### PR TITLE
feat: derive a market-implied point forecast from bucket order books

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1451,7 +1451,7 @@ Prediction markets price **ranges**, not values. A five-bucket EPS market says
 $2.14". These helpers invert that, collapsing the order books across every
 bucket of one market into the single number they collectively imply.
 
-```
+```text
 market says                     ->  forecast says
 "34% between 2.06 and 2.21"         "2.14, p10..p90 1.91..2.38"
 ```
@@ -1534,7 +1534,6 @@ market share a data stream and a settlement time.
 
 ```python
 from collections import defaultdict
-from trufnetwork_sdk_py import bucket_bounds_from_market_data
 
 groups = defaultdict(list)
 for summary in client.list_markets(settled_filter=False, limit=100):
@@ -1542,8 +1541,12 @@ for summary in client.list_markets(settled_filter=False, limit=100):
     market_data = client.decode_market_data(info["query_components"])
     groups[(market_data["stream_id"], summary["settle_time"])].append(summary["id"])
 
-# A complete market tiles the line: one "below" bucket, one "above", ranges between.
-for (stream_id, settle_time), query_ids in groups.items():
+# A complete market tiles the line: one "below" bucket, one "above", ranges
+# between. A stream can also carry a market that is not part of a bucket set at
+# all, so skip anything too small to forecast rather than letting it raise.
+for query_ids in groups.values():
+    if len(query_ids) < 2:
+        continue
     forecast = client.get_market_forecast(query_ids)
 ```
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1467,8 +1467,20 @@ Collapse a market's bucket books into the single value they imply.
 
 **Returns:** A `MarketForecast`, or `None` when no bucket has a usable quote.
 
-**Raises:** `ValueError` if fewer than two query_ids are given, or a market is
+**Raises:** `ValueError` if fewer than two query_ids are given, if any is
+repeated, if they do not all belong to the same market, or if a market is
 missing the `query_components` needed to derive its bounds.
+
+One forecast covers the buckets of **one** market. A repeated query_id would
+have its bucket counted twice, and mixing two markets would normalise unrelated
+probabilities into a single distribution — both are rejected rather than warned
+about. Buckets of one market differ only in their strike, so the identity
+compared is `(data_provider, stream_id, settle_time, timestamp, frozen_at)`.
+
+> `timestamp` and `frozen_at` come from `DecodeMarketData` in the compiled Go
+> bindings. The committed bindings predate those fields, so until they are
+> rebuilt the identity effectively rests on the first three; the check widens
+> automatically once they are present.
 
 **Cost:** two order-book reads plus one market-info read per bucket. Both the
 YES and NO books are fetched, because on this venue a resting BUY NO at *p* is

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1475,7 +1475,9 @@ One forecast covers the buckets of **one** market. A repeated query_id would
 have its bucket counted twice, and mixing two markets would normalise unrelated
 probabilities into a single distribution — both are rejected rather than warned
 about. Buckets of one market differ only in their strike, so the identity
-compared is `(data_provider, stream_id, settle_time, timestamp, frozen_at)`.
+compared is `(data_provider, stream_id, bridge, settle_time, timestamp,
+frozen_at)` — the bridge included because an identical question collateralised
+two ways is two markets with two separate books.
 
 > `timestamp` and `frozen_at` come from `DecodeMarketData` in the compiled Go
 > bindings. The committed bindings predate those fields, so until they are

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1444,6 +1444,152 @@ Get aggregated order book depth for a market outcome.
 
 **Returns:** List of depth levels with aggregated amounts at each price.
 
+### Market Forecasting
+
+Prediction markets price **ranges**, not values. A five-bucket EPS market says
+"34% chance EPS lands between $2.06 and $2.21"; it never says "EPS will be
+$2.14". These helpers invert that, collapsing the order books across every
+bucket of one market into the single number they collectively imply.
+
+```
+market says                     ->  forecast says
+"34% between 2.06 and 2.21"         "2.14, p10..p90 1.91..2.38"
+```
+
+#### `client.get_market_forecast(query_ids: list[int]) -> MarketForecast | None`
+
+Collapse a market's bucket books into the single value they imply.
+
+**Parameters:**
+- `query_ids: list[int]` - The bucket query_ids of **one** market. Order does
+  not matter; they are sorted by bound internally. See *Finding a market's
+  query_ids* below.
+
+**Returns:** A `MarketForecast`, or `None` when no bucket has a usable quote.
+
+**Raises:** `ValueError` if fewer than two query_ids are given, or a market is
+missing the `query_components` needed to derive its bounds.
+
+**Cost:** two order-book reads plus one market-info read per bucket. Both the
+YES and NO books are fetched, because on this venue a resting BUY NO at *p* is
+hittable by a BUY YES at *100-p* (mint match), so NO liquidity is executable
+YES liquidity and ignoring it would discard real quotes.
+
+**Example:**
+```python
+forecast = client.get_market_forecast([419, 420, 421, 422, 423])
+
+print(f"{forecast.value:.4f}")              # 2.1363
+print(f"{forecast.p10:.4f}..{forecast.p90:.4f}")   # 1.9058..2.3792
+
+for bucket in forecast.buckets:
+    print(f"  {bucket.lower}-{bucket.upper}: {bucket.probability:.1%}")
+
+for warning in forecast.warnings:
+    print(f"  ! {warning}")
+```
+
+#### `MarketForecast`
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `value` | `float` | The point estimate: the **median** of the implied distribution |
+| `p10`, `p90` | `float \| None` | The published band. The market implies an 80% chance the outcome lands inside it |
+| `margin_of_error` | `float` | Half the P10..P90 band. **Not** a standard error — see below |
+| `sigma` | `float` | The band scaled to a normal-equivalent standard deviation |
+| `value_basis` | `str` | `"interior"`, `"tail"`, or `"unresolved"` — see below |
+| `p10_basis`, `p90_basis` | `str` | Same flags, for each end of the band |
+| `method` | `str` | `"rank"` normally, `"discrete"` on a degenerate book |
+| `buckets` | `list[BucketEstimate]` | Per-bucket detail |
+| `warnings` | `list[str]` | Book-quality problems worth surfacing |
+| `multimodal`, `n_peaks` | `bool`, `int` | Whether the book implies more than one peak |
+| `low`, `high` | `float` | `value -/+ margin_of_error` |
+| `as_dict()` | `dict` | Flat, JSON-serialisable form |
+
+Each `BucketEstimate` carries `query_id`, `lower`, `upper`, `probability`
+(normalised, sums to 1), `raw_probability`, `confidence`, `one_sided` and
+`quoted`.
+
+**`margin_of_error` is a band, not a precision.** It is half the P10..P90
+spread, so it describes how uncertain the **outcome** is, not how tightly the
+book pins your estimate. Expect it to be large — on a live five-bucket EPS
+market, roughly 0.24 against a value of 2.14. Publishing it as "± 0.24" is
+correct; reading it as "our estimate is accurate to 0.24" is not.
+
+**Check the `_basis` flags before displaying a number.** The outer two buckets
+are open-ended, so the books say nothing about how far out they extend. When a
+percentile falls inside one, an exponential tail model supplies the number and
+the corresponding flag reads `"tail"`. `"interior"` means it was read between
+real strikes with no shape assumption. `"unresolved"` means the market has too
+few strikes to place it at all.
+
+**Read `warnings`.** Unquoted or one-sided buckets, crossed books, and
+dutch-book deviations are reported rather than silently smoothed over.
+
+#### Finding a market's query_ids
+
+Each bucket is a **separate market** with its own query_id, so a "market" is a
+set of them. They can be reassembled from chain data alone: buckets of the same
+market share a data stream and a settlement time.
+
+```python
+from collections import defaultdict
+from trufnetwork_sdk_py import bucket_bounds_from_market_data
+
+groups = defaultdict(list)
+for summary in client.list_markets(settled_filter=False, limit=100):
+    info = client.get_market_info(summary["id"])
+    market_data = client.decode_market_data(info["query_components"])
+    groups[(market_data["stream_id"], summary["settle_time"])].append(summary["id"])
+
+# A complete market tiles the line: one "below" bucket, one "above", ranges between.
+for (stream_id, settle_time), query_ids in groups.items():
+    forecast = client.get_market_forecast(query_ids)
+```
+
+A layout that does not tile the line is still estimated, with the problem
+reported in `warnings` rather than raised.
+
+#### Forecasting from your own book data
+
+If you already hold the books, the algorithm is available as pure functions with
+no I/O. `forecast_from_depth` is the preferred entry point; it consolidates the
+YES and NO ladders itself.
+
+```python
+from trufnetwork_sdk_py import (
+    BookLevel, BucketDepth, forecast_from_depth,
+    BucketBook, forecast_from_buckets,
+)
+
+# Full ladders. Prices are positive 1-99 cents on every side.
+buckets = [
+    BucketDepth(
+        lower=None, upper=1.91,            # None = open-ended outer bucket
+        yes_bids=[BookLevel(price=4, size=386)],
+        yes_asks=[],
+        no_bids=[BookLevel(price=83, size=25)],
+        no_asks=[BookLevel(price=97, size=6)],
+        query_id=419,
+    ),
+    # ... remaining buckets, ascending
+]
+forecast = forecast_from_depth(buckets)
+
+# Or, if you only have top-of-book (no consolidation, weaker estimate):
+forecast = forecast_from_buckets([
+    BucketBook(lower=None, upper=1.91, best_bid=4, best_ask=17, query_id=419),
+    # ...
+])
+```
+
+Buckets must span the whole line, with the first open below (`lower=None`) and
+the last open above (`upper=None`).
+
+`bucket_bounds_from_market_data(market_data)` converts the output of
+`decode_market_data` into a `(lower, upper)` pair, handling the `below`,
+`between`, `above` and `equals` market types.
+
 ### Settlement
 
 Markets are settled **automatically** by the network scheduler. No manual intervention is required.

--- a/src/trufnetwork_sdk_py/__init__.py
+++ b/src/trufnetwork_sdk_py/__init__.py
@@ -30,6 +30,19 @@ from .utils import (
     derive_maa_address,
     derive_maa_address_hex,
 )
+from .forecast import (
+    BookLevel,
+    BucketBook,
+    BucketDepth,
+    BucketEstimate,
+    MarketForecast,
+    bucket_estimate_from_depth,
+    bucket_probability,
+    typical_half_spread,
+    forecast_from_buckets,
+    forecast_from_depth,
+)
+from .market_buckets import bucket_bounds_from_market_data
 
 __all__ = [
     "TNClient",
@@ -61,4 +74,15 @@ __all__ = [
     "VISIBILITY_PRIVATE",
     "BulkInserter",
     "BulkInsertError",
+    "BookLevel",
+    "BucketBook",
+    "BucketDepth",
+    "BucketEstimate",
+    "MarketForecast",
+    "bucket_estimate_from_depth",
+    "bucket_probability",
+    "typical_half_spread",
+    "bucket_bounds_from_market_data",
+    "forecast_from_buckets",
+    "forecast_from_depth",
 ]

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -29,7 +29,7 @@ import warnings
 import trufnetwork_sdk_c_bindings.exports as truf_sdk
 import trufnetwork_sdk_c_bindings.go as go
 
-from typing import Any, TypedDict, Literal, cast, overload, Generic, TypeVar, Optional, Required
+from typing import Any, TypedDict, Literal, cast, overload, Generic, TypeVar, Optional, Required, NotRequired
 
 from pydantic import BaseModel
 
@@ -314,12 +314,22 @@ class DecodedQueryComponents(TypedDict):
 
 
 class MarketData(TypedDict):
-    """Structured content of a prediction market's query components"""
+    """Structured content of a prediction market's query components.
+
+    ``timestamp`` (the point in the stream the query observes, unix seconds) and
+    ``frozen_at`` (the block height the data is pinned to; None means latest)
+    are produced by ``contractsapi.DecodeMarketData`` in sdk-go, which this SDK
+    calls through its compiled bindings. They are ``NotRequired`` because the
+    committed bindings predate those fields: they appear once the bindings are
+    rebuilt against an sdk-go that emits them. Read them with ``.get()``.
+    """
     data_provider: str
     stream_id: str
     action_id: str
     type: Literal["above", "below", "between", "equals", "unknown"]
     thresholds: list[str]
+    timestamp: NotRequired[int | None]
+    frozen_at: NotRequired[int | None]
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -2851,23 +2861,32 @@ class TNClient:
             market_data = self.decode_market_data(query_components)
 
             # Buckets of one market differ only in their strike: they share a
-            # data provider, a stream and a settlement time. Forecasting across
-            # two events would normalise unrelated probabilities into one
-            # distribution and return a confident number about nothing, so it is
-            # rejected rather than warned about.
+            # data provider, a stream, a settlement time and the query time they
+            # observe. Forecasting across two events would normalise unrelated
+            # probabilities into one distribution and return a confident number
+            # about nothing, so it is rejected rather than warned about.
+            #
+            # timestamp/frozen_at come from sdk-go's DecodeMarketData through the
+            # compiled bindings. The committed bindings predate them, so today
+            # they are None for every bucket and contribute nothing; the check
+            # starts discriminating on them as soon as the bindings are rebuilt.
+            # Two markets can settle at the same moment while observing the
+            # stream at different points, which settle_time alone cannot see.
             this_identity = (
                 market_data.get("data_provider"),
                 market_data.get("stream_id"),
                 info.get("settle_time"),
+                market_data.get("timestamp"),
+                market_data.get("frozen_at"),
             )
             if identity is None:
                 identity = this_identity
             elif this_identity != identity:
                 raise ValueError(
                     f"market {query_id} belongs to a different event than the "
-                    f"first bucket: (data_provider, stream_id, settle_time) is "
-                    f"{this_identity} against {identity}. One forecast covers "
-                    "the buckets of ONE market."
+                    f"first bucket: (data_provider, stream_id, settle_time, "
+                    f"timestamp, frozen_at) is {this_identity} against "
+                    f"{identity}. One forecast covers the buckets of ONE market."
                 )
 
             lower, upper = bucket_bounds_from_market_data(market_data)

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -2831,8 +2831,15 @@ class TNClient:
             raise ValueError(
                 f"a market forecast needs at least 2 bucket query_ids, got {len(query_ids)}"
             )
+        if len(set(query_ids)) != len(query_ids):
+            repeated = sorted({q for q in query_ids if query_ids.count(q) > 1})
+            raise ValueError(
+                f"duplicate bucket query_ids {repeated}; a repeated bucket would "
+                "have its probability counted twice"
+            )
 
         books: list[BucketDepth] = []
+        identity: tuple | None = None
         for query_id in query_ids:
             info = self.get_market_info(query_id)
             query_components = info.get("query_components") or b""
@@ -2841,9 +2848,29 @@ class TNClient:
                     f"market {query_id} has no query_components, so its bucket "
                     "bounds cannot be derived"
                 )
-            lower, upper = bucket_bounds_from_market_data(
-                self.decode_market_data(query_components)
+            market_data = self.decode_market_data(query_components)
+
+            # Buckets of one market differ only in their strike: they share a
+            # data provider, a stream and a settlement time. Forecasting across
+            # two events would normalise unrelated probabilities into one
+            # distribution and return a confident number about nothing, so it is
+            # rejected rather than warned about.
+            this_identity = (
+                market_data.get("data_provider"),
+                market_data.get("stream_id"),
+                info.get("settle_time"),
             )
+            if identity is None:
+                identity = this_identity
+            elif this_identity != identity:
+                raise ValueError(
+                    f"market {query_id} belongs to a different event than the "
+                    f"first bucket: (data_provider, stream_id, settle_time) is "
+                    f"{this_identity} against {identity}. One forecast covers "
+                    "the buckets of ONE market."
+                )
+
+            lower, upper = bucket_bounds_from_market_data(market_data)
             yes_bids, yes_asks = self._order_book_ladders(query_id, True)
             no_bids, no_asks = self._order_book_ladders(query_id, False)
             books.append(

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -33,6 +33,14 @@ from typing import Any, TypedDict, Literal, cast, overload, Generic, TypeVar, Op
 
 from pydantic import BaseModel
 
+from .forecast import (
+    BookLevel,
+    BucketDepth,
+    MarketForecast,
+    forecast_from_depth,
+)
+from .market_buckets import bucket_bounds_from_market_data
+
 
 T = TypeVar("T")
 
@@ -2790,6 +2798,105 @@ class TNClient:
             return {"best_bid": None, "best_ask": None, "spread": None}
 
         return cast(BestPrices, json.loads(json_str))
+
+    def get_market_forecast(self, query_ids: list[int]) -> MarketForecast | None:
+        """Collapse a market's bucket books into the single value they imply.
+
+        A prediction market prices ranges: each bucket is its own query_id with
+        its own binary book. This reads every bucket's FULL YES and NO ladders
+        and its bounds, then returns the one number the books collectively
+        imply plus the band around it. See ``trufnetwork_sdk_py.forecast``.
+
+        The YES and NO books are both fetched because the forecast consolidates
+        them: on this venue a resting BUY NO at p is hittable by a BUY YES at
+        100-p (mint match), so NO liquidity is executable YES liquidity and
+        ignoring it would discard real quotes. That costs two order-book reads
+        per bucket.
+
+        Args:
+            query_ids: The bucket query_ids of ONE market. Order does not
+                matter, they are sorted by lower bound here. The buckets are
+                expected to tile the whole line, with the bottom one open below
+                and the top one open above; a layout that does not is still
+                estimated, with the problem reported in ``warnings``.
+
+        Returns:
+            A MarketForecast, or None when no bucket has a usable quote.
+
+        Raises:
+            ValueError: if fewer than two query_ids are given, or a market is
+                missing the query_components needed to derive its bounds.
+        """
+        if len(query_ids) < 2:
+            raise ValueError(
+                f"a market forecast needs at least 2 bucket query_ids, got {len(query_ids)}"
+            )
+
+        books: list[BucketDepth] = []
+        for query_id in query_ids:
+            info = self.get_market_info(query_id)
+            query_components = info.get("query_components") or b""
+            if not query_components:
+                raise ValueError(
+                    f"market {query_id} has no query_components, so its bucket "
+                    "bounds cannot be derived"
+                )
+            lower, upper = bucket_bounds_from_market_data(
+                self.decode_market_data(query_components)
+            )
+            yes_bids, yes_asks = self._order_book_ladders(query_id, True)
+            no_bids, no_asks = self._order_book_ladders(query_id, False)
+            books.append(
+                BucketDepth(
+                    lower=lower,
+                    upper=upper,
+                    yes_bids=yes_bids,
+                    yes_asks=yes_asks,
+                    no_bids=no_bids,
+                    no_asks=no_asks,
+                    query_id=query_id,
+                )
+            )
+
+        # None sorts first, which is where the open-below bucket belongs.
+        books.sort(key=lambda b: (b.lower is not None, b.lower))
+
+        layout: list[str] = []
+        if books[0].lower is not None:
+            layout.append("lowest bucket is not open below")
+        if books[-1].upper is not None:
+            layout.append("highest bucket is not open above")
+        breaks = sum(
+            1 for a, b in zip(books, books[1:]) if a.upper != b.lower
+        )
+        if breaks:
+            layout.append(f"{breaks} gap(s) or overlap(s) between bucket bounds")
+
+        forecast = forecast_from_depth(books)
+        if forecast is None:
+            return None
+        forecast.warnings[:0] = layout
+        return forecast
+
+    def _order_book_ladders(
+        self, query_id: int, outcome: bool
+    ) -> tuple[list[BookLevel], list[BookLevel]]:
+        """One outcome's resting book, split into (bids, asks) ladders.
+
+        ``get_order_book`` marks bids with a NEGATIVE price and asks with a
+        positive one; price 0 means shares held with no resting order, which is
+        not part of the book. Prices come back to the forecast as the positive
+        1-99 cent convention it expects.
+        """
+        bids: list[BookLevel] = []
+        asks: list[BookLevel] = []
+        for entry in self.get_order_book(query_id, outcome):
+            price, amount = entry["price"], entry["amount"]
+            if price < 0:
+                bids.append(BookLevel(price=float(-price), size=float(amount)))
+            elif price > 0:
+                asks.append(BookLevel(price=float(price), size=float(amount)))
+        return bids, asks
 
     def get_user_collateral(self) -> UserCollateral:
         """Get caller's total locked collateral value."""

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -2872,9 +2872,31 @@ class TNClient:
             # starts discriminating on them as soon as the bindings are rebuilt.
             # Two markets can settle at the same moment while observing the
             # stream at different points, which settle_time alone cannot see.
+            # A binary action always carries its timestamp; only frozen_at is
+            # nullable. A None timestamp would compare equal across buckets, so
+            # two malformed markets would COLLIDE on that component and match
+            # each other -- the check failing open in exactly the case it exists
+            # to catch. The key being ABSENT is different: that is the old
+            # bindings not emitting the field at all, which is not a defect in
+            # the market, so it is left alone.
+            if (
+                market_data.get("type") != "unknown"
+                and "timestamp" in market_data
+                and market_data["timestamp"] is None
+            ):
+                raise ValueError(
+                    f"market {query_id} carries no readable query timestamp, so "
+                    "it cannot be matched against the other buckets of its market"
+                )
+
+            # The bridge is the one identity field that lives outside the query
+            # components: it is a create_market argument, so two markets can ask
+            # an identical question while collateralising it differently. Those
+            # are separate markets with separate books.
             this_identity = (
                 market_data.get("data_provider"),
                 market_data.get("stream_id"),
+                info.get("bridge"),
                 info.get("settle_time"),
                 market_data.get("timestamp"),
                 market_data.get("frozen_at"),
@@ -2884,7 +2906,7 @@ class TNClient:
             elif this_identity != identity:
                 raise ValueError(
                     f"market {query_id} belongs to a different event than the "
-                    f"first bucket: (data_provider, stream_id, settle_time, "
+                    f"first bucket: (data_provider, stream_id, bridge, settle_time, "
                     f"timestamp, frozen_at) is {this_identity} against "
                     f"{identity}. One forecast covers the buckets of ONE market."
                 )

--- a/src/trufnetwork_sdk_py/forecast.py
+++ b/src/trufnetwork_sdk_py/forecast.py
@@ -1,0 +1,976 @@
+"""Market-implied point forecast from prediction-market order book state.
+
+Prediction markets price RANGES. A five-bucket EPS market says "38% chance EPS
+lands between $4.33 and $4.62"; it never says "EPS will be $4.47". This module
+inverts that. Given the order books across every bucket of one market, it
+produces the single number the book is collectively implying, together with how
+tightly the book pins that number down.
+
+    market says            ->   this module says
+    "34% between 2.40-2.63"     "2.43, margin of error 0.02"
+
+How it works
+------------
+A market is N buckets, each its own query_id and its own binary book, and the
+outer two are open-ended:
+
+    bucket 1  (-inf, B1)      bucket 2  [B1, B2)   ...   bucket N  [Bn-1, +inf)
+
+Bounds are HALF-OPEN, matching how the markets are actually created
+(`market_generator.py`: `value < upper`, `value >= lower AND value < upper`,
+`value >= lower`). So the buckets are mutually exclusive and exhaustive, and a
+value landing exactly on a boundary resolves the UPPER bucket only.
+
+1. Each bucket's book implies a probability. Two-sided is the mid, with
+   confidence from how tight the spread is. One-sided takes the quoted side and
+   steps across by the market's own median half-spread, at reduced confidence:
+   on real books the open tail buckets are often bid-only at a penny, and
+   treating that as the midpoint of [0.01, 1.0] calls a dead tail a coin flip.
+   That single mistake handed MSFT's two tails 27% each and buried the real
+   distribution, so the rule matters more than it looks.
+
+2. Bucket probabilities are normalised to sum to 1, since independent books
+   never sum to exactly 1 on their own because of spreads and staleness. A
+   bucket with no orders at all takes the residual the quoted buckets leave
+   behind rather than an invented value.
+
+3. Those give the implied CDF at each interior boundary: the probability the
+   outcome lands at or below B_k is the sum of the buckets up to k.
+
+4. A normal is fitted through those CDF points by weighted least squares on the
+   probit scale, so B_k ~= mu + sigma * z_k. The fit is what makes the open
+   tails tractable: no assumption is needed about how far bucket 1 extends,
+   because the tail buckets constrain the fit through their probability mass
+   rather than through any assumed value. Fitting a normal is also consistent
+   with how these markets are constructed, since the bucket boundaries are laid
+   out on z-scores in the first place.
+
+The point estimate is the MEDIAN read directly off that CDF (rank method):
+walk up the cumulative probabilities until they cross 50% and interpolate
+within the bucket where the crossing happens. No distribution shape is
+assumed for anything interior. The published band is P10..P90 read the same
+way. When a requested percentile falls inside an OPEN-ENDED outer bucket the
+books contain no information about how far out it lies, so an exponential
+tail matched to the adjacent bucket's density supplies a number, and the
+result is flagged (`value_basis` / `p10_basis` / `p90_basis` = "tail") so
+consumers can decide whether to show it. Markets struck so that the mass
+stays between the outer boundaries never need the tail model at all.
+
+A normal fit was the previous method and remains in the file as a diagnostic
+only. Its known failures (confidently wrong on bimodal books, grid-dependent
+near expiry) are what the rank method replaces.
+
+`confidence` per bucket is (1 - spread) * min(1, n / median(n)) with n the
+thinner side's committed dollars, standardised against the market's own
+depth so no external constant is needed. It does not move the median; it is
+published as book quality and drives warnings.
+"""
+
+# Ported verbatim from truflation/prediction-bots @ main 21fe4f3 (PR #37),
+# whose last change to this file was fafe52b. Upstream path:
+# market-maker-bot/src/market_maker_bot/forecast.py
+#
+# Kept byte-identical on purpose: the algorithm is validated against live
+# mainnet books there and is still moving fast, so re-syncing must stay a diff
+# rather than a re-write. Change it upstream first, then copy the file across.
+# To check for drift, diff this file against upstream ignoring this header.
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from statistics import NormalDist
+from typing import List, Optional, Sequence
+
+__all__ = [
+    "BucketBook",
+    "BucketEstimate",
+    "MarketForecast",
+    "BookLevel",
+    "BucketDepth",
+    "bucket_probability",
+    "bucket_estimate_from_depth",
+    "typical_half_spread",
+    "forecast_from_buckets",
+    "forecast_from_depth",
+]
+
+# Probabilities are clamped this far away from 0 and 1 before the probit
+# transform, since Phi^-1(0) and Phi^-1(1) are infinite.
+_EPS = 1e-4
+
+# A bracket at least this wide contributes essentially nothing to the fit.
+_MIN_CONFIDENCE = 1e-3
+
+# Half-spread used to complete a one-sided quote when the market gives us
+# nothing better. Bounds keep a pathological book from imputing a silly step.
+_DEFAULT_HALF_SPREAD = 0.06
+_MIN_HALF_SPREAD = 0.01
+_MAX_HALF_SPREAD = 0.20
+
+# A quote below this notional is treated as absent. Size does not enter the
+# forecast itself, so without a floor a single tiny order at a silly price moves
+# the published number as much as a real one: one 90c bid on a dead tail shifted
+# a bimodal market by 8 units, for 90c of risk. Only applied when sizes are
+# supplied; callers that pass none keep the old behaviour.
+MIN_QUOTE_NOTIONAL_CENT_SHARES = 100
+
+# The buckets are mutually exclusive and exhaustive, so the asks must cost at
+# least 1 and the bids must not pay more than 1. Outside these, someone is
+# giving money away. Warned on rather than normalised silently.
+_DUTCH_BOOK_TOLERANCE = 0.02
+
+# Depth path only. A side whose ENTIRE ladder holds less than this many dollars
+# is treated as absent: with the full book summed, dust cannot hide in front of
+# a real order, so a small floor is enough to make sub-dollar griefing quotes
+# weightless. Tunable.
+DEPTH_MIN_SIDE_NOTIONAL_USD = 5.0
+
+# Disclosure threshold only, never part of the math: a market whose books hold
+# less than this in total gets a warning attached, because relative
+# standardisation cannot see absolute poverty.
+LOW_TOTAL_NOTIONAL_WARN_USD = 50.0
+
+# A second density peak only counts as real multimodality if it reaches this
+# fraction of the tallest peak; below it is quote noise.
+PEAK_PROMINENCE = 0.20
+
+_NORM = NormalDist()
+
+
+@dataclass(frozen=True)
+class BucketBook:
+    """One bucket's bounds and its best two-sided quote, in cents.
+
+    ``lower``/``upper`` are None for the open-ended outer buckets. Prices are
+    the positive 1-99 cent convention for the bucket's YES side; None means no
+    resting order on that side.
+    """
+
+    lower: Optional[float]
+    upper: Optional[float]
+    best_bid: Optional[float] = None
+    best_ask: Optional[float] = None
+    query_id: Optional[int] = None
+    bid_size: Optional[float] = None
+    ask_size: Optional[float] = None
+
+    def _usable(self, price: Optional[float], size: Optional[float]) -> Optional[float]:
+        """Drop a top-of-book quote too small to mean anything.
+
+        LIMITATION: this only sees the best level. If a dust order is sitting in
+        front of a real one, dropping it here marks the whole bucket unpriced
+        rather than falling back to the real quote behind it, which can be worse
+        than not filtering at all. Callers that hold the full book should instead
+        pass the best level whose size clears the floor, and leave these
+        arguments unset. This is a backstop, not the fix.
+        """
+        if price is None or size is None:
+            return price
+        return price if price * size >= MIN_QUOTE_NOTIONAL_CENT_SHARES else None
+
+    def usable_bid(self) -> Optional[float]:
+        return self._usable(self.best_bid, self.bid_size)
+
+    def usable_ask(self) -> Optional[float]:
+        return self._usable(self.best_ask, self.ask_size)
+
+
+@dataclass(frozen=True)
+class BookLevel:
+    """One resting level: price in cents (positive, 1-99), size in shares."""
+
+    price: float
+    size: float
+
+
+@dataclass(frozen=True)
+class BucketDepth:
+    """One bucket's FULL ladders on all four sides.
+
+    The YES and NO books are consolidated inside this module because the
+    inversion is executable, not merely informative. Verified on testnet
+    (2026-08-03): the protocol's fill hierarchy matches EXACT inverses. A
+    resting BUY NO at p mint-matches an incoming BUY YES at 100-p (one pair
+    minted for $1), and a resting SELL NO at p burn-matches an incoming SELL
+    YES at 100-p (one pair merged for $1). So:
+
+        consolidated bids = yes_bids + (100 - p for every NO ask)
+        consolidated asks = yes_asks + (100 - p for every NO bid)
+
+    both sides hittable at exactly the inverted price. There is no
+    price-improvement crossing: near-inverses (sums other than 100) rest.
+    """
+
+    lower: Optional[float]
+    upper: Optional[float]
+    yes_bids: Sequence[BookLevel] = ()
+    yes_asks: Sequence[BookLevel] = ()
+    no_bids: Sequence[BookLevel] = ()
+    no_asks: Sequence[BookLevel] = ()
+    query_id: Optional[int] = None
+
+    def consolidated_bids(self) -> List[BookLevel]:
+        lv = [l for l in self.yes_bids if l.size > 0]
+        lv += [BookLevel(round(100.0 - l.price, 4), l.size)
+               for l in self.no_asks if l.size > 0]
+        return sorted(lv, key=lambda l: -l.price)
+
+    def consolidated_asks(self) -> List[BookLevel]:
+        lv = [l for l in self.yes_asks if l.size > 0]
+        lv += [BookLevel(round(100.0 - l.price, 4), l.size)
+               for l in self.no_bids if l.size > 0]
+        return sorted(lv, key=lambda l: l.price)
+
+    def best_view(self) -> "BucketBook":
+        """The consolidated best quotes, for spread/dutch-book helpers."""
+        bids, asks = self.consolidated_bids(), self.consolidated_asks()
+        return BucketBook(
+            self.lower, self.upper,
+            bids[0].price if bids else None,
+            asks[0].price if asks else None,
+            self.query_id,
+        )
+
+
+@dataclass(frozen=True)
+class BucketEstimate:
+    """What one bucket's book implies about its probability."""
+
+    query_id: Optional[int]
+    lower: Optional[float]
+    upper: Optional[float]
+    probability: float          # normalised, sums to 1 across the market
+    raw_probability: float      # before normalisation
+    confidence: float           # 0 = no usable quote, 1 = tight two-sided
+    one_sided: bool
+    quoted: bool
+
+
+@dataclass
+class MarketForecast:
+    """The single value a market's order books imply.
+
+    ``value`` is the MEDIAN of the implied distribution. ``p10``/``p90`` are
+    the published band. Each carries a basis flag: "interior" means it was
+    read between real strikes with no shape assumption; "tail" means it fell
+    inside an open-ended outer bucket and rests on the exponential tail model;
+    "unresolved" means the market has too few strikes to place it at all.
+
+    ``margin_of_error`` is kept for downstream compatibility as half the
+    P10..P90 band; ``sigma`` as the band scaled to a normal-equivalent
+    standard deviation (band / 2.5631). Prefer the quantiles directly.
+    """
+
+    value: float
+    margin_of_error: float
+    sigma: float
+    method: str                 # "rank" or "discrete"
+    buckets: List[BucketEstimate] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    p10: Optional[float] = None
+    p90: Optional[float] = None
+    value_basis: str = "interior"
+    p10_basis: str = "interior"
+    p90_basis: str = "interior"
+    multimodal: bool = False
+    n_peaks: int = 1
+
+    @property
+    def low(self) -> float:
+        return self.value - self.margin_of_error
+
+    @property
+    def high(self) -> float:
+        return self.value + self.margin_of_error
+
+    def as_dict(self) -> dict:
+        """Flat form for SDKs and the indexer."""
+        return {
+            "value": self.value,
+            "value_basis": self.value_basis,
+            "p10": self.p10,
+            "p90": self.p90,
+            "p10_basis": self.p10_basis,
+            "p90_basis": self.p90_basis,
+            "margin_of_error": self.margin_of_error,
+            "low": self.low,
+            "high": self.high,
+            "sigma": self.sigma,
+            "method": self.method,
+            "multimodal": self.multimodal,
+            "probabilities": [b.probability for b in self.buckets],
+            "warnings": list(self.warnings),
+        }
+
+
+def typical_half_spread(buckets: Sequence["BucketBook"]) -> float:
+    """Half the market's median two-sided spread, as a probability.
+
+    Used to complete one-sided quotes. A missing side is usually an artifact of
+    our own quoting (no inventory to sell, or the self-cross guard suppressing
+    a leg) rather than a statement about probability, so the other side is
+    still informative once shifted by the spread this market actually trades.
+    """
+    spreads = [
+        (b.best_ask - b.best_bid) / 100.0
+        for b in buckets
+        if b.best_bid is not None
+        and b.best_ask is not None
+        and b.best_ask >= b.best_bid
+    ]
+    if not spreads:
+        return _DEFAULT_HALF_SPREAD
+    spreads.sort()
+    mid = len(spreads) // 2
+    median = (
+        spreads[mid]
+        if len(spreads) % 2
+        else (spreads[mid - 1] + spreads[mid]) / 2.0
+    )
+    return max(_MIN_HALF_SPREAD, min(median / 2.0, _MAX_HALF_SPREAD))
+
+
+def bucket_probability(
+    best_bid: Optional[float],
+    best_ask: Optional[float],
+    half_spread: float = _DEFAULT_HALF_SPREAD,
+) -> tuple[Optional[float], float, bool, bool]:
+    """Turn one bucket's best quote into (probability, confidence, one_sided, quoted).
+
+    Two-sided is the easy case: the mid, with confidence from how tight the
+    spread is.
+
+    One-sided needs care. Treating a lone 1c bid as the midpoint of [0.01, 1.0]
+    would call it a coin flip, which is badly wrong: on real mainnet books the
+    open tail buckets are frequently bid-only at a penny, and the midpoint rule
+    handed them 27% each and buried the actual distribution. The quoted side is
+    the only real information, so we take it and step across by the market's own
+    half-spread, then mark the confidence down.
+
+    An unquoted bucket returns None. It is NOT 0.5: the caller assigns it the
+    residual probability the quoted buckets leave behind, which is what the
+    market actually implies about it.
+    """
+    quoted = best_bid is not None or best_ask is not None
+    if not quoted:
+        return None, 0.0, False, False
+
+    one_sided = best_bid is None or best_ask is None
+
+    if not one_sided:
+        lo = max(0.0, min(1.0, best_bid / 100.0))
+        hi = max(0.0, min(1.0, best_ask / 100.0))
+        if hi < lo:
+            # Crossed book: bid above ask. Either stale, or free money. The old
+            # code kept the midpoint at low confidence, but confidence only
+            # affects the FIT WEIGHT -- the bogus probability still entered the
+            # normalisation and shifted every CDF point. Treat it as unquoted so
+            # the caller can assign it the residual instead.
+            return None, 0.0, one_sided, quoted
+        return (lo + hi) / 2.0, 1.0 - (hi - lo), one_sided, quoted
+
+    if best_bid is not None:
+        p = best_bid / 100.0 + half_spread
+    else:
+        p = best_ask / 100.0 - half_spread
+    p = max(0.0, min(1.0, p))
+    # Confidence of a two-sided book at this spread, halved: we inferred one
+    # side rather than observing it.
+    return p, max(_MIN_CONFIDENCE, (1.0 - 2.0 * half_spread) / 2.0), one_sided, quoted
+
+
+def _boundaries(buckets: Sequence[BucketBook]) -> List[float]:
+    """Interior boundaries, i.e. the upper edge of every bucket but the last."""
+    return [b.upper for b in buckets[:-1] if b.upper is not None]
+
+
+def _fit_normal(
+    boundaries: Sequence[float],
+    cumulative: Sequence[float],
+    weights: Sequence[float],
+) -> Optional[tuple[float, float, float]]:
+    """Weighted least-squares fit of B_k = mu + sigma * z_k.
+
+    Weights combine quote quality with PROBIT LEVERAGE. A boundary out in the
+    tail carries a cumulative probability near 0 or 1, where dz/dC = 1/phi(z) is
+    enormous, so a 1c quote error there swings z far more than the same error at
+    the centre. Weighting by quote tightness alone let those noisy tail points
+    dominate: on a near-resolved book (1/1/1/96/1) the fit returned a value
+    OUTSIDE the 96% bucket. Scaling by phi(z)^2 is the delta-method correction
+    and puts it back inside (0.634 -> 1.119).
+
+    Returns (mu, sigma, standard_error_of_mu), or None if the points cannot
+    support a fit.
+    """
+    # Two different weightings, deliberately kept apart. `ws` drives the
+    # regression and carries the phi(z)^2 leverage correction. `confs` stays on
+    # the original 0..1 quote-quality scale and is the only thing the confidence
+    # floor below may use: folding phi(z)^2 into it would read a perfectly good
+    # book as near-zero confidence, since phi(z)^2 <= 0.16 by construction.
+    zs, bs, ws, confs = [], [], [], []
+    for b, c, w in zip(boundaries, cumulative, weights):
+        if w <= _MIN_CONFIDENCE:
+            continue
+        c = min(max(c, _EPS), 1.0 - _EPS)
+        z = _NORM.inv_cdf(c)
+        zs.append(z)
+        bs.append(b)
+        ws.append(w * _NORM.pdf(z) ** 2)
+        confs.append(w)
+    if ws and max(ws) <= 0:
+        return None
+
+    n = len(zs)
+    if n < 2:
+        return None
+
+    sw = sum(ws)
+    mean_z = sum(w * z for w, z in zip(ws, zs)) / sw
+    mean_b = sum(w * b for w, b in zip(ws, bs)) / sw
+    szz = sum(w * (z - mean_z) ** 2 for w, z in zip(ws, zs))
+    if szz <= 0:
+        # Every usable boundary carries the same implied probability, so the
+        # book says nothing about the spread and the slope is unidentifiable.
+        return None
+    szb = sum(w * (z - mean_z) * (b - mean_b) for w, z, b in zip(ws, zs, bs))
+
+    sigma = szb / szz
+    mu = mean_b - sigma * mean_z
+    if not (sigma > 0) or not math.isfinite(mu):
+        return None
+
+    # Standard error of the intercept under weighted least squares. With only
+    # two points the fit is exact and the residual variance is zero, so fall
+    # back to a spread-based floor rather than claiming infinite precision.
+    dof = n - 2
+    if dof > 0:
+        resid = sum(
+            w * (b - (mu + sigma * z)) ** 2 for w, z, b in zip(ws, zs, bs)
+        )
+        s2 = resid / dof
+        se = math.sqrt(max(s2, 0.0) * (1.0 / sw + mean_z**2 / szz))
+    else:
+        se = 0.0
+
+    # However well the points line up, we cannot pin the centre tighter than
+    # the quotes themselves allow. Confidence-weighted so a wide or one-sided
+    # book widens the band instead of flattering it.
+    avg_conf = sum(confs) / max(len(confs), 1)
+    floor = sigma * (1.0 - avg_conf) / max(math.sqrt(n), 1.0)
+    return mu, sigma, max(se, floor)
+
+
+def _discrete_fallback(
+    estimates: Sequence[BucketEstimate], boundaries: Sequence[float]
+) -> tuple[float, float]:
+    """Probability-weighted bucket midpoints, for when the fit cannot run.
+
+    The open tails have no midpoint, so they are represented by their finite
+    edge pushed out by half the average interior width. Cruder than the fit and
+    biased toward the centre, which is why it is only a fallback.
+    """
+    widths = [
+        hi - lo
+        for lo, hi in zip(boundaries, boundaries[1:])
+        if hi is not None and lo is not None
+    ]
+    pad = (sum(widths) / len(widths) / 2.0) if widths else 0.0
+
+    points, probs = [], []
+    for est in estimates:
+        if est.lower is None and est.upper is None:
+            continue
+        if est.lower is None:
+            point = est.upper - pad
+        elif est.upper is None:
+            point = est.lower + pad
+        else:
+            point = (est.lower + est.upper) / 2.0
+        points.append(point)
+        probs.append(est.probability)
+
+    total = sum(probs)
+    if total <= 0 or not points:
+        return float("nan"), float("nan")
+
+    mean = sum(p * x for p, x in zip(probs, points)) / total
+    var = sum(p * (x - mean) ** 2 for p, x in zip(probs, points)) / total
+    return mean, math.sqrt(max(var, 0.0))
+
+
+def _discrete_margin(sigma: float, estimates: Sequence["BucketEstimate"]) -> float:
+    """A margin of error for the discrete fallback.
+
+    The old code published `sigma` here, which the module docstring explicitly
+    warns against: sigma is how uncertain the OUTCOME is, not how well the book
+    pins our estimate. The fallback also represents each open tail by an invented
+    point, so its centre is genuinely less trustworthy than a fitted one. Scale
+    sigma down by the number of buckets we could actually read, and floor it so a
+    fallback can never claim to be tighter than a real fit.
+    """
+    quoted = sum(1 for e in estimates if e.quoted) or 1
+    conf = sum(e.confidence for e in estimates) / max(len(estimates), 1)
+    return sigma * (1.0 - 0.5 * conf) / math.sqrt(quoted)
+
+
+def _dutch_book_warning(buckets: Sequence["BucketBook"]) -> Optional[str]:
+    """Mutually exclusive and exhaustive buckets bound the book.
+
+    Buying YES in every bucket guarantees exactly 1, so the asks must sum to at
+    least 1. Minting a pair in every bucket and selling all the YES also settles
+    at 1, so the bids must not sum to more than 1. A violation is risk-free money
+    against us, and the previous +/-15% tolerance on the MIDS let a 14c box pass
+    with no warning at all.
+    """
+    asks = [b.usable_ask() for b in buckets]
+    bids = [b.usable_bid() for b in buckets]
+    if all(a is not None for a in asks):
+        total = sum(asks) / 100.0
+        if total < 1.0 - _DUTCH_BOOK_TOLERANCE:
+            return (f"DUTCH BOOK: asks sum to {total:.3f}; buying every bucket costs "
+                    f"{total:.3f} and settles at 1.000, a risk-free "
+                    f"{(1.0 - total) * 100:.1f}c per dollar against us")
+    if all(b is not None for b in bids):
+        total = sum(bids) / 100.0
+        if total > 1.0 + _DUTCH_BOOK_TOLERANCE:
+            return (f"DUTCH BOOK: bids sum to {total:.3f}; minting and selling every "
+                    f"bucket pays {total:.3f} against a cost of 1.000, a risk-free "
+                    f"{(total - 1.0) * 100:.1f}c per dollar against us")
+    return None
+
+
+def _rank_quantile(
+    bounds: Sequence[float], probs: Sequence[float], q: float
+) -> tuple[Optional[float], str]:
+    """Percentile q read directly off the piecewise-linear implied CDF.
+
+    Interior crossings interpolate between real strikes and assume nothing
+    beyond uniform density within the bucket. A crossing inside an open-ended
+    outer bucket needs a shape for the tail; we use an exponential decay
+    matched to the adjacent interior bucket's density, and flag the result
+    "tail" so consumers know it rests on that assumption. With fewer than two
+    boundaries there is no interior at all and no density to anchor a tail,
+    so the answer is (None, "unresolved").
+    """
+    k = len(probs)
+    cum: List[float] = []
+    run = 0.0
+    for p in probs[:-1]:
+        run += p
+        cum.append(run)
+    if len(bounds) < 2:
+        return None, "unresolved"
+    for i in range(1, k - 1):                      # interior buckets
+        lo_c = cum[i - 1]
+        hi_c = cum[i]
+        if lo_c <= q <= hi_c:
+            lo_b, hi_b = bounds[i - 1], bounds[i]
+            if hi_c <= lo_c:
+                return (lo_b + hi_b) / 2.0, "interior"
+            frac = (q - lo_c) / (hi_c - lo_c)
+            return lo_b + frac * (hi_b - lo_b), "interior"
+    widths = [bounds[i + 1] - bounds[i] for i in range(len(bounds) - 1)]
+    if q < cum[0]:                                  # lower open tail
+        dens = probs[1] / widths[0] if widths[0] > 0 else 0.0
+        if dens <= 0 or cum[0] <= 0:
+            return None, "unresolved"
+        lam = dens / cum[0]
+        return bounds[0] + math.log(q / cum[0]) / lam, "tail"
+    upper_mass = probs[-1]                          # upper open tail
+    dens = probs[-2] / widths[-1] if widths[-1] > 0 else 0.0
+    if dens <= 0 or upper_mass <= 0:
+        return None, "unresolved"
+    lam = dens / upper_mass
+    return bounds[-1] - math.log(max((1.0 - q), 1e-12) / upper_mass) / lam, "tail"
+
+
+def _count_peaks(bounds: Sequence[float], probs: Sequence[float]) -> int:
+    """Prominent local maxima of the interior density profile.
+
+    A peak only counts if it reaches PEAK_PROMINENCE of the tallest one, so a
+    penny-noise bump next to a 96% bucket does not read as bimodality. Open
+    tails carry no density profile, so tail-heavy bimodality is seen through
+    the interior buckets adjacent to the tails.
+    """
+    widths = [bounds[i + 1] - bounds[i] for i in range(len(bounds) - 1)]
+    dens = [probs[i + 1] / w if w > 0 else 0.0 for i, w in enumerate(widths)]
+    if not dens:
+        return 1
+    top = max(dens)
+    if top <= 0:
+        return 1
+    peaks = 0
+    for i, d in enumerate(dens):
+        is_max = (i == 0 or d > dens[i - 1]) and (i == len(dens) - 1 or d >= dens[i + 1])
+        if is_max and d >= PEAK_PROMINENCE * top:
+            peaks += 1
+    return max(peaks, 1)
+
+
+def _assemble(
+    meta: Sequence[tuple],
+    bids_cents: Sequence[Optional[float]],
+    raw: List[Optional[float]],
+    confs: List[float],
+    one_sided_flags: List[bool],
+    quoted_flags: List[bool],
+    warnings: List[str],
+) -> Optional[MarketForecast]:
+    """Shared back half of the pipeline: normalise the per-bucket estimates,
+    build the implied CDF, fit, or fall back. ``meta`` is (lower, upper,
+    query_id) per bucket; ``bids_cents`` is each bucket's best bid, used only
+    to bound what an unpriced bucket could claim."""
+    if not any(quoted_flags):
+        return None
+    n_missing = sum(1 for p in raw if p is None)
+    n_unquoted = sum(1 for q in quoted_flags if not q)
+    n_crossed = n_missing - n_unquoted
+    if n_unquoted:
+        warnings.append(f"{n_unquoted} of {len(meta)} buckets unquoted")
+    if n_crossed:
+        warnings.append(
+            f"{n_crossed} bucket(s) crossed (bid above ask); treated as unpriced"
+        )
+    if any(one_sided_flags):
+        warnings.append(
+            f"{sum(one_sided_flags)} bucket(s) one-sided; margin of error widened"
+        )
+
+    quoted_total = sum(p for p in raw if p is not None)
+    if quoted_total <= 0:
+        return None
+    if abs(quoted_total - 1.0) > _DUTCH_BOOK_TOLERANCE:
+        # Independent books never sum to exactly 1. Report the SIGNED deviation
+        # rather than a wide dead band: the direction says whether the book is
+        # over- or under-priced, and the old +/-15% window hid real boxes.
+        warnings.append(
+            f"bucket mids sum to {quoted_total:.3f} "
+            f"({(quoted_total - 1.0) * 100:+.1f}c per dollar) before normalising"
+        )
+
+    filled = list(raw)
+    if n_missing:
+        # An unpriced bucket is UNKNOWN, not impossible. Its probability is
+        # bounded above by whatever the other buckets' BIDS do not already
+        # claim, since bids are a lower bound on their true probabilities.
+        # Take the midpoint of that interval. Asserting zero (the old
+        # behaviour whenever quoted mids summed above 1) is a strong claim
+        # the book never made.
+        bid_claim = sum(
+            (bc or 0.0) / 100.0
+            for bc, p in zip(bids_cents, raw)
+            if p is not None
+        )
+        headroom = max(0.0, 1.0 - bid_claim)
+        est = headroom / (2.0 * n_missing)
+        filled = [est if p is None else p for p in raw]
+
+    total = sum(p for p in filled if p is not None)
+    if total <= 0:
+        return None
+    probs = [(p or 0.0) / total for p in filled]
+
+    estimates = [
+        BucketEstimate(
+            query_id=m[2],
+            lower=m[0],
+            upper=m[1],
+            probability=p,
+            raw_probability=(r if r is not None else 0.0),
+            confidence=c,
+            one_sided=o,
+            quoted=q,
+        )
+        for m, p, r, c, o, q in zip(
+            meta, probs, raw, confs, one_sided_flags, quoted_flags
+        )
+    ]
+
+    bounds = [m[1] for m in meta[:-1] if m[1] is not None]
+    if len(bounds) != len(meta) - 1:
+        warnings.append("bucket bounds incomplete; falling back to discrete estimate")
+        value, sigma = _discrete_fallback(estimates, bounds)
+        if math.isnan(value):
+            return None
+        return MarketForecast(
+            value, _discrete_margin(sigma, estimates), sigma, "discrete",
+            estimates, warnings,
+        )
+
+    # Rank method: read the percentiles straight off the implied CDF.
+    med, med_basis = _rank_quantile(bounds, probs, 0.50)
+    p10, p10_basis = _rank_quantile(bounds, probs, 0.10)
+    p90, p90_basis = _rank_quantile(bounds, probs, 0.90)
+
+    if med is None:
+        warnings.append(
+            "median unresolvable from these strikes; falling back to discrete estimate"
+        )
+        value, sigma = _discrete_fallback(estimates, bounds)
+        if math.isnan(value):
+            return None
+        return MarketForecast(
+            value, _discrete_margin(sigma, estimates), sigma, "discrete",
+            estimates, warnings,
+        )
+
+    if med_basis == "tail":
+        outside = probs[0] if probs[0] >= 0.5 else probs[-1]
+        warnings.append(
+            f"median lies beyond the outer strikes ({outside * 100:.0f}% of mass "
+            f"in an open-ended bucket); value depends on the assumed tail shape"
+        )
+    for nm, basis in (("p10", p10_basis), ("p90", p90_basis)):
+        if basis == "tail":
+            warnings.append(f"{nm} falls in an open tail; tail-model dependent")
+        elif basis == "unresolved":
+            warnings.append(f"{nm} unresolvable from these strikes")
+
+    n_peaks = _count_peaks(bounds, probs)
+    multimodal = n_peaks >= 2
+    if multimodal:
+        warnings.append(
+            f"market shows {n_peaks} probability clusters; a single point "
+            f"forecast misrepresents it, publish the clusters instead"
+        )
+
+    if p10 is not None and p90 is not None:
+        band = max(p90 - p10, 0.0)
+        margin = band / 2.0
+        sigma = band / 2.5631          # P10..P90 of a normal spans 2.5631 sigma
+    else:
+        margin = sigma = 0.0
+        warnings.append("band unresolvable; margin and sigma reported as 0")
+
+    return MarketForecast(
+        med, margin, sigma, "rank", estimates, warnings,
+        p10=p10, p90=p90, value_basis=med_basis,
+        p10_basis=p10_basis, p90_basis=p90_basis,
+        multimodal=multimodal, n_peaks=n_peaks,
+    )
+
+
+def forecast_from_buckets(buckets: Sequence[BucketBook]) -> Optional[MarketForecast]:
+    """Collapse one market's bucket books into a single implied value, from
+    best quotes only.
+
+    Buckets must be supplied in ascending order and span the whole line, with
+    the first open below and the last open above. Returns None when the book
+    carries no usable information at all. When full ladders are available,
+    prefer :func:`forecast_from_depth`, which weights by committed notional.
+    """
+    warnings: List[str] = []
+
+    if len(buckets) < 2:
+        return None
+
+    half = typical_half_spread(buckets)
+
+    dutch = _dutch_book_warning(buckets)
+    if dutch:
+        warnings.append(dutch)
+
+    raw: List[Optional[float]] = []
+    confs: List[float] = []
+    one_sided_flags: List[bool] = []
+    quoted_flags: List[bool] = []
+    for b in buckets:
+        p, conf, one_sided, quoted = bucket_probability(
+            b.usable_bid(), b.usable_ask(), half
+        )
+        raw.append(p)
+        confs.append(conf)
+        one_sided_flags.append(one_sided)
+        quoted_flags.append(quoted)
+
+    return _assemble(
+        [(b.lower, b.upper, b.query_id) for b in buckets],
+        [b.usable_bid() for b in buckets],
+        raw, confs, one_sided_flags, quoted_flags, warnings,
+    )
+
+
+def _side_stats(levels: Sequence[BookLevel]) -> tuple[float, float, float]:
+    """(vwap_cents, notional_usd, shares) over a full ladder.
+
+    The full-ladder VWAP no longer prices anything (see _walk_price); dollars
+    are the currency for confidence and the dust floors, since posting many
+    shares of a cheap side is not the same commitment as posting the same
+    dollars.
+    """
+    cent_shares = sum(l.price * l.size for l in levels)
+    shares = sum(l.size for l in levels)
+    return cent_shares / shares, cent_shares / 100.0, shares
+
+
+def _walk_price(levels: Sequence[BookLevel], target_usd: float) -> float:
+    """Dollar-weighted price of executing ``target_usd`` from the touch.
+
+    Walk the ladder best-first, consuming each level's own notional until the
+    target is reached; the last level fills partially. Each committed dollar
+    carries the same weight regardless of the price it rests at, which is the
+    whole point: per-dollar influence must not depend on denomination, or
+    penny ladders (25 shares per dollar at 4c) out-vote real money.
+
+    Callers guarantee the ladder holds at least ``target_usd`` in total (the
+    side floor); if it somehow does not, the walk prices what is there.
+    """
+    remaining = target_usd * 100.0  # cent-shares
+    weighted = taken = 0.0
+    for l in levels:
+        if remaining <= 0:
+            break
+        take = min(l.price * l.size, remaining)
+        weighted += take * l.price
+        taken += take
+        remaining -= take
+    return weighted / taken
+
+
+def bucket_estimate_from_depth(
+    depth: BucketDepth,
+    half_spread: float = _DEFAULT_HALF_SPREAD,
+) -> tuple[Optional[float], float, float, bool, bool]:
+    """One bucket's implied probability from its full consolidated ladders.
+
+    Returns (probability, quality, notional_usd, one_sided, quoted).
+
+    The probability is the midpoint of the two executable walk prices: the
+    dollar-weighted price of selling DEPTH_MIN_SIDE_NOTIONAL_USD into the
+    consolidated bids and of buying the same from the consolidated asks,
+    clamped into [best bid, best ask]. A book only pins the truth to that
+    interval, so the estimate must be a selection from it; depth beyond the
+    first walk dollars is inventory, not opinion, and moves confidence only.
+
+    This replaced a full-book share-weighted microprice, which let cheap
+    ladders out-vote real money (a dollar at 4c is 25 shares, at 30c it is 3)
+    and on live books pushed every sub-50c bucket above its own best ask
+    (issue #36). Ladder imbalance moves the walk mid not at all: on this venue
+    all resting flow is the market maker's own, so imbalance carries no
+    information and would only be a free manipulation lever.
+
+    ``quality`` is the spread component of confidence: (1 - spread) two-sided,
+    halved for a one-sided book whose missing side was inferred. ``notional``
+    is the committed dollars backing the estimate: the THINNER side when both
+    exist, the quoted side otherwise. The caller standardises notional against
+    the market's own median depth to finish the confidence; no external
+    constant is involved.
+
+    Sides whose whole ladder holds under DEPTH_MIN_SIDE_NOTIONAL_USD are
+    treated as absent: with the full book summed, dust cannot hide in front
+    of a real order. Trades are deliberately NOT used: resting depth is live,
+    at-risk capital, and the venue's only taker is a designed noise trader.
+    """
+    bids = depth.consolidated_bids()
+    asks = depth.consolidated_asks()
+    b_vwap = b_ntl = b_sh = a_vwap = a_ntl = a_sh = None
+    if bids:
+        b_vwap, b_ntl, b_sh = _side_stats(bids)
+        if b_ntl < DEPTH_MIN_SIDE_NOTIONAL_USD:
+            bids, b_vwap, b_ntl, b_sh = [], None, None, None
+    if asks:
+        a_vwap, a_ntl, a_sh = _side_stats(asks)
+        if a_ntl < DEPTH_MIN_SIDE_NOTIONAL_USD:
+            asks, a_vwap, a_ntl, a_sh = [], None, None, None
+
+    quoted = bool(bids or asks)
+    if not quoted:
+        return None, 0.0, 0.0, False, False
+    one_sided = not (bids and asks)
+
+    if not one_sided:
+        best_bid, best_ask = bids[0].price, asks[0].price
+        if best_bid >= best_ask:
+            # Crossed at the consolidated touch: stale or free money.
+            return None, 0.0, 0.0, one_sided, quoted
+        walk_bid = _walk_price(bids, DEPTH_MIN_SIDE_NOTIONAL_USD)
+        walk_ask = _walk_price(asks, DEPTH_MIN_SIDE_NOTIONAL_USD)
+        p = (walk_bid + walk_ask) / 2.0
+        p = max(best_bid, min(best_ask, p)) / 100.0
+        spread = (best_ask - best_bid) / 100.0
+        return (
+            max(0.0, min(1.0, p)),
+            max(1.0 - spread, _MIN_CONFIDENCE),
+            min(b_ntl, a_ntl),
+            one_sided,
+            quoted,
+        )
+
+    if bids:
+        p = _walk_price(bids, DEPTH_MIN_SIDE_NOTIONAL_USD) / 100.0 + half_spread
+        n = b_ntl
+    else:
+        p = _walk_price(asks, DEPTH_MIN_SIDE_NOTIONAL_USD) / 100.0 - half_spread
+        n = a_ntl
+    quality = (1.0 - 2.0 * half_spread) / 2.0
+    return max(0.0, min(1.0, p)), max(quality, _MIN_CONFIDENCE), n, one_sided, quoted
+
+
+def forecast_from_depth(buckets: Sequence[BucketDepth]) -> Optional[MarketForecast]:
+    """Collapse one market's bucket books into a single implied value, using
+    FULL YES and NO ladders weighted by committed notional.
+
+    This is the preferred entry point. The YES/NO consolidation happens here,
+    per bucket, because the inversion is executable on this venue (exact
+    inverse mint/burn matching, verified on testnet 2026-08-03), so callers
+    should not have to know the rule.
+    """
+    warnings: List[str] = []
+
+    if len(buckets) < 2:
+        return None
+
+    views = [b.best_view() for b in buckets]
+    half = typical_half_spread(views)
+
+    dutch = _dutch_book_warning(views)
+    if dutch:
+        warnings.append(dutch)
+
+    raw: List[Optional[float]] = []
+    qualities: List[float] = []
+    notionals: List[float] = []
+    one_sided_flags: List[bool] = []
+    quoted_flags: List[bool] = []
+    for b in buckets:
+        p, quality, n_usd, one_sided, quoted = bucket_estimate_from_depth(b, half)
+        raw.append(p)
+        qualities.append(quality)
+        notionals.append(n_usd)
+        one_sided_flags.append(one_sided)
+        quoted_flags.append(quoted)
+
+    # Confidence = quality * min(1, n / median(n)), the market standardised
+    # against its own depth. Median rather than max or sum so a single whale
+    # bucket cannot crush its siblings' credibility.
+    priced_n = sorted(n for p, n in zip(raw, notionals) if p is not None and n > 0)
+    med_n = priced_n[len(priced_n) // 2] if len(priced_n) % 2 else (
+        (priced_n[len(priced_n) // 2 - 1] + priced_n[len(priced_n) // 2]) / 2.0
+    ) if priced_n else 0.0
+    confs: List[float] = []
+    for p, quality, n_usd in zip(raw, qualities, notionals):
+        if p is None:
+            confs.append(0.0)
+        elif med_n > 0:
+            confs.append(max(quality * min(1.0, n_usd / med_n), _MIN_CONFIDENCE))
+        else:
+            confs.append(quality)
+
+    # Disclosure, never math: relative standardisation cannot see absolute
+    # poverty, so a market that is thin EVERYWHERE gets a visible caveat.
+    total_usd = 0.0
+    for b in buckets:
+        for side in (b.consolidated_bids(), b.consolidated_asks()):
+            if side:
+                total_usd += _side_stats(side)[1]
+    if total_usd < LOW_TOTAL_NOTIONAL_WARN_USD:
+        warnings.append(
+            f"total resting notional only ${total_usd:,.0f} across all buckets"
+        )
+
+    return _assemble(
+        [(b.lower, b.upper, b.query_id) for b in buckets],
+        [v.best_bid for v in views],
+        raw, confs, one_sided_flags, quoted_flags, warnings,
+    )

--- a/src/trufnetwork_sdk_py/market_buckets.py
+++ b/src/trufnetwork_sdk_py/market_buckets.py
@@ -5,6 +5,7 @@ verbatim mirror of the upstream algorithm in truflation/prediction-bots and
 must stay diffable against it. Nothing here is part of the forecast maths.
 """
 
+import math
 from typing import Any
 
 
@@ -36,20 +37,51 @@ def bucket_bounds_from_market_data(
                 f"a {market_type!r} market needs at least {index + 1} threshold(s), "
                 f"got {len(thresholds)}"
             )
-        return float(thresholds[index])
+        value = float(thresholds[index])
+        # float() accepts "nan", "inf" and "-inf" without complaint. Those would
+        # flow all the way into the forecast and surface as a NaN value rather
+        # than as this market being unreadable.
+        if not math.isfinite(value):
+            raise ValueError(
+                f"threshold {index} of a {market_type!r} market is not finite: "
+                f"{thresholds[index]!r}"
+            )
+        return value
 
     if market_type == "below":
         return None, threshold(0)
     if market_type == "above":
         return threshold(0), None
     if market_type == "between":
-        return threshold(0), threshold(1)
+        lower, upper = threshold(0), threshold(1)
+        # Bounds are half-open [lower, upper), so lower == upper is an empty
+        # bucket and lower > upper is an inverted one. Neither can hold an
+        # outcome, and both would quietly distort the tiling.
+        if lower >= upper:
+            raise ValueError(
+                f"a {market_type!r} market needs lower < upper, "
+                f"got [{lower}, {upper})"
+            )
+        return lower, upper
     if market_type == "equals":
         # thresholds are (target, tolerance), NOT (lower, upper). Reading them
         # positionally the way `between` is read would give an inverted bucket
         # and be silently wrong rather than loud.
         target, tolerance = threshold(0), threshold(1)
-        return target - tolerance, target + tolerance
+        if tolerance <= 0:
+            raise ValueError(
+                f"an {market_type!r} market needs a positive tolerance, "
+                f"got {tolerance}"
+            )
+        lower, upper = target - tolerance, target + tolerance
+        # Both operands are finite, but the sum or difference can still overflow
+        # near the float limits.
+        if not math.isfinite(lower) or not math.isfinite(upper):
+            raise ValueError(
+                f"an {market_type!r} market with target {target} and tolerance "
+                f"{tolerance} overflows its bounds"
+            )
+        return lower, upper
 
     raise ValueError(
         f"cannot derive bucket bounds from a {market_type!r} market"

--- a/src/trufnetwork_sdk_py/market_buckets.py
+++ b/src/trufnetwork_sdk_py/market_buckets.py
@@ -1,0 +1,56 @@
+"""Bucket bounds from a decoded prediction market's query components.
+
+SDK-side glue, deliberately kept OUT of ``forecast.py``: that module is a
+verbatim mirror of the upstream algorithm in truflation/prediction-bots and
+must stay diffable against it. Nothing here is part of the forecast maths.
+"""
+
+from typing import Any
+
+
+def bucket_bounds_from_market_data(
+    market_data: dict[str, Any],
+) -> tuple[float | None, float | None]:
+    """Turn one bucket market's decoded data into its ``(lower, upper)`` bounds.
+
+    ``None`` means open-ended, which is how the outer two buckets of a market
+    are always struck. Bounds are half-open ``[lower, upper)`` upstream, so a
+    value landing exactly on a boundary resolves the upper bucket only.
+
+    Args:
+        market_data: the result of ``TNClient.decode_market_data``.
+
+    Returns:
+        ``(lower, upper)``, either of which may be None.
+
+    Raises:
+        ValueError: if the market type cannot describe a bucket, or the
+            thresholds needed for that type are missing.
+    """
+    market_type = market_data.get("type")
+    thresholds = market_data.get("thresholds") or []
+
+    def threshold(index: int) -> float:
+        if len(thresholds) <= index:
+            raise ValueError(
+                f"a {market_type!r} market needs at least {index + 1} threshold(s), "
+                f"got {len(thresholds)}"
+            )
+        return float(thresholds[index])
+
+    if market_type == "below":
+        return None, threshold(0)
+    if market_type == "above":
+        return threshold(0), None
+    if market_type == "between":
+        return threshold(0), threshold(1)
+    if market_type == "equals":
+        # thresholds are (target, tolerance), NOT (lower, upper). Reading them
+        # positionally the way `between` is read would give an inverted bucket
+        # and be silently wrong rather than loud.
+        target, tolerance = threshold(0), threshold(1)
+        return target - tolerance, target + tolerance
+
+    raise ValueError(
+        f"cannot derive bucket bounds from a {market_type!r} market"
+    )

--- a/src/trufnetwork_sdk_py/market_buckets.py
+++ b/src/trufnetwork_sdk_py/market_buckets.py
@@ -74,12 +74,14 @@ def bucket_bounds_from_market_data(
                 f"got {tolerance}"
             )
         lower, upper = target - tolerance, target + tolerance
-        # Both operands are finite, but the sum or difference can still overflow
-        # near the float limits.
-        if not math.isfinite(lower) or not math.isfinite(upper):
+        # A positive tolerance does not guarantee a non-empty bucket. Near the
+        # float limits the sum can overflow to inf, and a tolerance small enough
+        # relative to the target is absorbed entirely, collapsing both edges onto
+        # the same value: 1e300 +/- 1e-300 is 1e300 twice.
+        if not math.isfinite(lower) or not math.isfinite(upper) or lower >= upper:
             raise ValueError(
                 f"an {market_type!r} market with target {target} and tolerance "
-                f"{tolerance} overflows its bounds"
+                f"{tolerance} does not describe a usable bucket: [{lower}, {upper})"
             )
         return lower, upper
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,0 +1,219 @@
+"""Tests for the market-implied point forecast."""
+
+import math
+
+import pytest
+
+from trufnetwork_sdk_py.forecast import (
+    BucketBook,
+    bucket_probability,
+    forecast_from_buckets,
+)
+
+# MSFT EPS 2026 Q3 bucket layout, as configured on mainnet.
+MSFT_BOUNDS = [(None, 4.04), (4.04, 4.33), (4.33, 4.62), (4.62, 4.92), (4.92, None)]
+
+
+def build(probs_cents, bounds=MSFT_BOUNDS, spread=2):
+    """Books quoting each bucket at the given cents, with a symmetric spread."""
+    out = []
+    for (lo, hi), c in zip(bounds, probs_cents):
+        if c is None:
+            out.append(BucketBook(lo, hi))
+        else:
+            out.append(
+                BucketBook(lo, hi, max(1, c - spread / 2), min(99, c + spread / 2))
+            )
+    return out
+
+
+# --- bracket logic -----------------------------------------------------------
+
+
+def test_two_sided_quote_is_the_midpoint():
+    p, conf, one_sided, quoted = bucket_probability(38, 42)
+    assert p == pytest.approx(0.40)
+    assert conf == pytest.approx(0.96)
+    assert not one_sided and quoted
+
+
+def test_tighter_spread_means_more_confidence():
+    _, tight, _, _ = bucket_probability(39, 41)
+    _, wide, _, _ = bucket_probability(20, 60)
+    assert tight > wide
+
+
+def test_one_sided_book_steps_across_by_the_half_spread():
+    """A lone bid is real information, but it is a BID: the fair value sits a
+    half-spread above it, not at the midpoint of [bid, 1]."""
+    p, conf, one_sided, quoted = bucket_probability(30, None, half_spread=0.06)
+    assert one_sided and quoted
+    assert p == pytest.approx(0.36)
+    assert conf < 0.75, "we inferred one side rather than observing it"
+
+
+def test_lone_penny_bid_is_not_a_coin_flip():
+    """The bug live books exposed: [0.01, 1.0] midpoint made dead tails 50%."""
+    p, _, _, _ = bucket_probability(1, None, half_spread=0.06)
+    assert p == pytest.approx(0.07)
+    assert p < 0.15
+
+
+def test_empty_book_returns_none_not_a_number():
+    p, conf, one_sided, quoted = bucket_probability(None, None)
+    assert p is None
+    assert conf == pytest.approx(0.0)
+    assert not quoted and not one_sided
+
+
+def test_crossed_book_is_distrusted():
+    _, conf, _, _ = bucket_probability(60, 40)
+    assert conf <= 1e-3
+
+
+# --- the core estimate -------------------------------------------------------
+
+
+def test_symmetric_market_centres_on_the_middle_bucket():
+    """Mass symmetric about bucket 3 must imply its midpoint, (4.33+4.62)/2."""
+    f = forecast_from_buckets(build([5, 20, 50, 20, 5]))
+    assert f is not None and f.method == "rank"
+    assert f.value == pytest.approx(4.475, abs=0.03)
+    assert f.value_basis == "interior"
+
+
+def test_forecast_moves_with_the_mass():
+    low = forecast_from_buckets(build([40, 30, 20, 7, 3])).value
+    mid = forecast_from_buckets(build([5, 20, 50, 20, 5])).value
+    high = forecast_from_buckets(build([3, 7, 20, 30, 40])).value
+    assert low < mid < high
+
+
+def test_forecast_lands_inside_the_leading_bucket():
+    f = forecast_from_buckets(build([5, 10, 60, 20, 5]))
+    assert 4.33 <= f.value <= 4.62
+
+
+def test_open_tails_do_not_need_an_assumed_value():
+    """Heavy mass in the unbounded top bucket must still give a finite answer
+    that sits above the last boundary."""
+    f = forecast_from_buckets(build([1, 2, 7, 20, 70]))
+    assert f is not None
+    assert math.isfinite(f.value)
+    assert f.value > 4.92
+
+
+def test_probabilities_are_normalised():
+    f = forecast_from_buckets(build([10, 25, 55, 25, 10]))  # sums to 125c
+    assert sum(b.probability for b in f.buckets) == pytest.approx(1.0)
+    assert any("sum to" in w for w in f.warnings)
+
+
+# --- the two uncertainties ---------------------------------------------------
+
+
+def test_band_is_the_published_uncertainty():
+    """Under the rank method the band IS the uncertainty statement: the market
+    says the outcome lands in [p10, p90] with 80% probability. margin and
+    sigma are derived from it for compatibility."""
+    f = forecast_from_buckets(build([5, 20, 50, 20, 5]))
+    assert f.p10 is not None and f.p90 is not None
+    assert f.p10 < f.value < f.p90
+    assert f.margin_of_error == pytest.approx((f.p90 - f.p10) / 2)
+    assert f.sigma == pytest.approx((f.p90 - f.p10) / 2.5631)
+
+
+def test_tight_books_pin_the_value_better_than_wide_ones():
+    tight = forecast_from_buckets(build([5, 20, 50, 20, 5], spread=2))
+    wide = forecast_from_buckets(build([5, 20, 50, 20, 5], spread=30))
+    assert wide.margin_of_error > tight.margin_of_error
+
+
+def test_one_sided_books_widen_the_margin():
+    two_sided = forecast_from_buckets(build([5, 20, 50, 20, 5]))
+    half = [
+        BucketBook(lo, hi, c, None)
+        for (lo, hi), c in zip(MSFT_BOUNDS, [5, 20, 50, 20, 5])
+    ]
+    one_sided = forecast_from_buckets(half)
+    assert one_sided.margin_of_error > two_sided.margin_of_error
+    assert any("one-sided" in w for w in one_sided.warnings)
+
+
+def test_low_high_bracket_the_value():
+    f = forecast_from_buckets(build([5, 20, 50, 20, 5]))
+    assert f.low < f.value < f.high
+    assert f.high - f.low == pytest.approx(2 * f.margin_of_error)
+
+
+# --- degenerate input --------------------------------------------------------
+
+
+def test_no_quotes_at_all_returns_none():
+    assert forecast_from_buckets(build([None] * 5)) is None
+
+
+def test_too_few_buckets_returns_none():
+    assert forecast_from_buckets([BucketBook(None, 4.0, 40, 44)]) is None
+
+
+def test_partial_book_still_produces_an_estimate():
+    f = forecast_from_buckets(build([None, 20, 50, 20, None]))
+    assert f is not None and math.isfinite(f.value)
+    assert any("unquoted" in w for w in f.warnings)
+
+
+def test_unquoted_buckets_take_the_residual_not_a_flat_half():
+    """Quoted buckets sum to ~0.9, so the two unquoted ones share ~0.1 between
+    them, rather than being handed 0.5 each and swamping the distribution."""
+    f = forecast_from_buckets(build([None, 20, 50, 20, None]))
+    probs = [b.probability for b in f.buckets]
+    assert probs[0] == pytest.approx(probs[4])
+    assert probs[0] < 0.10, f"unquoted tail took {probs[0]:.0%}"
+    assert probs[2] > 0.4, "the quoted leading bucket must still dominate"
+
+
+def test_dead_tails_do_not_dominate_a_live_middle():
+    """Reproduces the live MSFT book: penny-bid one-sided tails around a tight
+    two-sided middle. The tails must not come out level with the leader."""
+    f = forecast_from_buckets(
+        [
+            BucketBook(None, 4.04, 1, None),
+            BucketBook(4.04, 4.33, 16, 28),
+            BucketBook(4.33, 4.62, 44, 56),
+            BucketBook(4.62, 4.92, 9, 21),
+            BucketBook(4.92, None, 1, None),
+        ]
+    )
+    probs = [b.probability for b in f.buckets]
+    assert probs[2] == max(probs), "the tight 44-56 bucket must lead"
+    assert probs[0] < 0.15 and probs[4] < 0.15, f"tails took {probs[0]:.0%}/{probs[4]:.0%}"
+    assert 4.2 <= f.value <= 4.7
+
+
+def test_all_mass_in_one_bucket_does_not_explode():
+    f = forecast_from_buckets(build([1, 1, 95, 1, 1]))
+    assert f is not None
+    assert math.isfinite(f.value) and math.isfinite(f.margin_of_error)
+    assert 4.0 <= f.value <= 5.0
+
+
+def test_flat_book_falls_back_rather_than_dividing_by_zero():
+    """Identical quotes everywhere say nothing about spread, so the probit
+    slope is unidentifiable and the discrete path must take over."""
+    f = forecast_from_buckets(build([20, 20, 20, 20, 20]))
+    assert f is not None and math.isfinite(f.value)
+
+
+def test_as_dict_is_serialisable():
+    d = forecast_from_buckets(build([5, 20, 50, 20, 5])).as_dict()
+    assert set(d) >= {"value", "margin_of_error", "low", "high", "sigma", "method"}
+    assert len(d["probabilities"]) == 5
+    assert all(isinstance(v, (int, float, str, list)) for v in d.values())
+
+
+def test_monotonic_cdf_is_enforced():
+    """Noisy quotes can imply a tiny negative probability step; the probit
+    transform must not see a decreasing CDF."""
+    f = forecast_from_buckets(build([30, 1, 40, 1, 28]))
+    assert f is not None and math.isfinite(f.value)

--- a/tests/test_forecast_depth.py
+++ b/tests/test_forecast_depth.py
@@ -1,0 +1,306 @@
+"""Tests for the depth-weighted forecast path.
+
+The depth path consolidates the YES and NO ladders inside the module (the
+inversion is executable via exact-inverse mint/burn matching, verified on
+testnet 2026-08-03) and weights each bucket by committed notional rather than
+reading best quotes alone.
+"""
+
+import math
+
+import pytest
+
+from trufnetwork_sdk_py.forecast import (
+    BookLevel,
+    BucketBook,
+    BucketDepth,
+    bucket_estimate_from_depth,
+    forecast_from_buckets,
+    forecast_from_depth,
+)
+
+# MSFT-shaped bounds, as on mainnet.
+BOUNDS = [(None, 4.04), (4.04, 4.33), (4.33, 4.62), (4.62, 4.92), (4.92, None)]
+
+
+def ladder(mid, size=100, levels=3, spread=2.0, step=1.0):
+    """Symmetric YES ladders plus the exact NO mirror our MM would post."""
+    yb = [BookLevel(round(mid - spread / 2 - k * step, 4), size) for k in range(levels)]
+    ya = [BookLevel(round(mid + spread / 2 + k * step, 4), size) for k in range(levels)]
+    nb = [BookLevel(round(100 - l.price, 4), l.size) for l in ya]
+    na = [BookLevel(round(100 - l.price, 4), l.size) for l in yb]
+    return yb, ya, nb, na
+
+
+def build(mids, sizes=None, bounds=BOUNDS):
+    out = []
+    for i, ((lo, hi), m) in enumerate(zip(bounds, mids)):
+        if m is None:
+            out.append(BucketDepth(lo, hi))
+            continue
+        yb, ya, nb, na = ladder(m, size=(sizes[i] if sizes else 100))
+        out.append(BucketDepth(lo, hi, yb, ya, nb, na))
+    return out
+
+
+# --- consolidation ----------------------------------------------------------
+
+
+def test_no_bid_becomes_executable_ask():
+    d = BucketDepth(None, 4.04, no_bids=[BookLevel(83, 50)])
+    asks = d.consolidated_asks()
+    assert asks and asks[0].price == pytest.approx(17.0)
+    assert asks[0].size == 50
+
+
+def test_no_ask_becomes_executable_bid():
+    d = BucketDepth(None, 4.04, no_asks=[BookLevel(95, 40)])
+    bids = d.consolidated_bids()
+    assert bids and bids[0].price == pytest.approx(5.0)
+
+
+def test_consolidated_sides_are_sorted_best_first():
+    d = BucketDepth(
+        None, 4.04,
+        yes_bids=[BookLevel(30, 10)],
+        yes_asks=[BookLevel(40, 10)],
+        no_bids=[BookLevel(65, 10)],   # -> ask at 35, better than the YES ask
+        no_asks=[BookLevel(68, 10)],   # -> bid at 32, better than the YES bid
+    )
+    assert d.consolidated_bids()[0].price == pytest.approx(32.0)
+    assert d.consolidated_asks()[0].price == pytest.approx(35.0)
+
+
+# --- the walk mid -----------------------------------------------------------
+
+
+def test_symmetric_depth_gives_the_mid():
+    yb, ya, nb, na = ladder(40.0)
+    p, quality, n_usd, one_sided, quoted = bucket_estimate_from_depth(
+        BucketDepth(None, 4.04, yb, ya, nb, na)
+    )
+    assert p == pytest.approx(0.40, abs=1e-6)
+    assert quoted and not one_sided
+    assert n_usd > 0
+
+
+def test_ladder_imbalance_does_not_move_the_price():
+    """Size imbalance is denomination and inventory, not opinion (issue #36):
+    on this venue all resting flow is the MM's own, so extra size behind the
+    walk must leave the estimate exactly where it was."""
+    yb, ya, nb, na = ladder(40.0)
+    heavy_bids = [BookLevel(l.price, l.size * 10) for l in yb]
+    p_heavy = bucket_estimate_from_depth(
+        BucketDepth(None, 4.04, heavy_bids, ya, [], [])
+    )[0]
+    p_flat = bucket_estimate_from_depth(
+        BucketDepth(None, 4.04, yb, ya, [], [])
+    )[0]
+    assert p_heavy == pytest.approx(p_flat)
+
+
+def test_estimate_stays_between_best_bid_and_ask():
+    """The book only pins the truth to [best bid, best ask]; a published
+    probability outside the executable bracket is dutch-bookable. The old
+    microprice gave 18.4 on this real NVDA bucket against a best ask of 17."""
+    d = BucketDepth(
+        None, 1.91,
+        yes_bids=[BookLevel(4, 386), BookLevel(3, 519), BookLevel(1, 1558)],
+        no_bids=[BookLevel(83, 6), BookLevel(81, 25)],
+        no_asks=[BookLevel(97, 3), BookLevel(99, 20)],
+    )
+    p = bucket_estimate_from_depth(d)[0]
+    bids, asks = d.consolidated_bids(), d.consolidated_asks()
+    assert bids[0].price / 100.0 <= p <= asks[0].price / 100.0
+
+
+def test_fragmented_side_is_priced_not_dropped():
+    """$5.77 of real asks split across two sub-$5 levels must still price the
+    side (the floor is on the side total, never per level), so splitting an
+    order into small clips cannot silence a side."""
+    d = BucketDepth(
+        None, 1.91,
+        yes_bids=[BookLevel(4, 386)],
+        no_bids=[BookLevel(83, 6), BookLevel(81, 25)],  # asks 17 ($1.02), 19 ($4.75)
+    )
+    p, quality, n_usd, one_sided, quoted = bucket_estimate_from_depth(d)
+    assert quoted and not one_sided
+    # sell $5 at 4c; buy $5 = $1.02 at 17 then $3.98 at 19 -> 18.59; mid 11.3
+    assert p == pytest.approx(0.113, abs=0.001)
+
+
+def test_size_behind_the_walk_is_weightless():
+    """100k shares added at 1c behind the first $5 of bids must not move the
+    estimate by a single bit."""
+    yb, ya, nb, na = ladder(40.0)
+    base = bucket_estimate_from_depth(BucketDepth(None, 4.04, yb, ya, nb, na))[0]
+    spammed = list(yb) + [BookLevel(1, 100_000)]
+    p = bucket_estimate_from_depth(BucketDepth(None, 4.04, spammed, ya, nb, na))[0]
+    assert p == base
+
+
+def test_thin_touch_walks_to_the_real_depth():
+    """A $1.68 best ask cannot speak for the side alone: the $5 walk carries
+    into the next level, blending 42 and 45 by their committed dollars."""
+    d = BucketDepth(
+        2.06, 2.21,
+        yes_bids=[BookLevel(30, 7), BookLevel(29, 54), BookLevel(27, 58)],
+        yes_asks=[BookLevel(42, 4), BookLevel(45, 44)],
+    )
+    p = bucket_estimate_from_depth(d)[0]
+    # sell $5: $2.10 at 30 + $2.90 at 29 = 29.42; buy $5: $1.68 at 42 +
+    # $3.32 at 45 = 43.99; mid 36.7
+    assert p == pytest.approx(0.367, abs=0.001)
+
+
+def test_confidence_is_standardised_within_the_market():
+    """Confidence compares each bucket to its OWN market's median depth, so a
+    bucket at typical depth earns the full spread quality and a bucket at a
+    fraction of typical depth is discounted proportionally. No external
+    dollar constant is involved, and one whale bucket cannot crush the rest
+    because the standard is the median."""
+    b = build([62.5, 31.25, 6.25],
+              sizes=[500, 500, 20],
+              bounds=[(None, 1.0), (1.0, 2.0), (2.0, None)])
+    f = forecast_from_depth(b)
+    confs = [e.confidence for e in f.buckets]
+    assert confs[0] == pytest.approx(confs[1])
+    assert confs[2] < confs[1] * 0.2, "the thin bucket must be discounted"
+
+    whale = build([62.5, 31.25, 6.25],
+                  sizes=[500, 50000, 500],
+                  bounds=[(None, 1.0), (1.0, 2.0), (2.0, None)])
+    fw = forecast_from_depth(whale)
+    assert fw.buckets[0].confidence == pytest.approx(confs[0], rel=0.05), (
+        "a whale in one bucket must not crush its siblings' confidence"
+    )
+
+
+# --- the issue #36 book, frozen ---------------------------------------------
+
+# Live NVDA EPS book, 2026-08-03. Under the old share-weighted microprice the
+# five raw estimates summed to 1.359 and two buckets priced above their own
+# best ask. The walk mid must keep every bucket inside its touch and the raw
+# sum near 1 (spread-wide, not ladder-wide).
+
+NVDA_FROZEN = [
+    BucketDepth(None, 1.91,
+                yes_bids=[BookLevel(4, 386), BookLevel(3, 519), BookLevel(1, 1558)],
+                no_bids=[BookLevel(83, 6), BookLevel(81, 25)],
+                no_asks=[BookLevel(97, 3), BookLevel(99, 20)]),
+    BucketDepth(1.91, 2.06,
+                yes_bids=[BookLevel(17, 96), BookLevel(16, 18), BookLevel(14, 122)],
+                no_bids=[BookLevel(70, 19), BookLevel(68, 29)],
+                no_asks=[BookLevel(84, 5)]),
+    BucketDepth(2.06, 2.21,
+                yes_bids=[BookLevel(30, 7), BookLevel(29, 54), BookLevel(27, 58)],
+                yes_asks=[BookLevel(42, 4), BookLevel(45, 44)],
+                no_bids=[BookLevel(57, 7), BookLevel(55, 28)],
+                no_asks=[BookLevel(70, 16)]),
+    BucketDepth(2.21, 2.35,
+                yes_bids=[BookLevel(15, 62), BookLevel(14, 111), BookLevel(12, 130)],
+                yes_asks=[BookLevel(27, 35)],
+                no_bids=[BookLevel(72, 16), BookLevel(70, 29)],
+                no_asks=[BookLevel(99, 6)]),
+    BucketDepth(2.35, None,
+                yes_bids=[BookLevel(4, 499), BookLevel(3, 667), BookLevel(1, 2000)],
+                no_bids=[BookLevel(75, 37), BookLevel(74, 24), BookLevel(73, 51)],
+                no_asks=[BookLevel(97, 3), BookLevel(99, 20)]),
+]
+
+
+def test_frozen_book_every_bucket_inside_its_touch():
+    for d in NVDA_FROZEN:
+        p = bucket_estimate_from_depth(d)[0]
+        bids, asks = d.consolidated_bids(), d.consolidated_asks()
+        assert bids[0].price / 100.0 <= p <= asks[0].price / 100.0, d.lower
+
+
+def test_frozen_book_raw_sum_is_spread_wide_not_inflated():
+    raw = [bucket_estimate_from_depth(d)[0] for d in NVDA_FROZEN]
+    total = sum(raw)
+    lo = sum(d.consolidated_bids()[0].price for d in NVDA_FROZEN) / 100.0
+    hi = sum(d.consolidated_asks()[0].price for d in NVDA_FROZEN) / 100.0
+    assert lo <= total <= hi
+    assert total < 1.10, f"was 1.359 under the microprice, got {total:.3f}"
+
+
+# --- griefing ---------------------------------------------------------------
+
+
+def test_dust_ladder_is_weightless():
+    """A 1-share 90c bid on a dead tail moved the old estimator by 8 units.
+    Summed over the full book it is $0.90, under the side floor, so absent."""
+    base = build([45, 5, 1, 5, 45],
+                 bounds=[(None, -2.0), (-2.0, -1.0), (-1.0, 1.0), (1.0, 2.0), (2.0, None)])
+    f0 = forecast_from_depth(base)
+    griefed = list(base)
+    griefed[4] = BucketDepth(2.0, None, yes_bids=[BookLevel(90, 1)])
+    f1 = forecast_from_depth(griefed)
+    # the dusted bucket contributes exactly what an unquoted one would
+    assert f1.value == pytest.approx(
+        forecast_from_depth(base[:4] + [BucketDepth(2.0, None)]).value
+    )
+    assert abs(f1.value - f0.value) < abs(0.0 - 8.0), "must not swing like before"
+
+
+def test_real_size_at_the_same_price_does_count():
+    base = build([45, 5, 1, 5, 45],
+                 bounds=[(None, -2.0), (-2.0, -1.0), (-1.0, 1.0), (1.0, 2.0), (2.0, None)])
+    sized = list(base)
+    sized[4] = BucketDepth(2.0, None, yes_bids=[BookLevel(90, 50)])  # $45 resting
+    f0 = forecast_from_depth(base)
+    f1 = forecast_from_depth(sized)
+    assert f1.value != pytest.approx(f0.value), "a funded quote must matter"
+
+
+# --- degenerate input -------------------------------------------------------
+
+
+def test_all_empty_returns_none():
+    assert forecast_from_depth(
+        [BucketDepth(lo, hi) for lo, hi in BOUNDS]
+    ) is None
+
+
+def test_one_sided_bucket_survives():
+    b = build([62.5, 31.25, None],
+              bounds=[(None, 1.0), (1.0, 2.0), (2.0, None)])
+    b[2] = BucketDepth(2.0, None, no_bids=[BookLevel(93, 100)])  # ask-only after inversion
+    f = forecast_from_depth(b)
+    assert f is not None and math.isfinite(f.value)
+
+
+def test_crossed_consolidated_touch_is_unpriced():
+    """YES bid 61.5 vs NO bid 45 -> consolidated ask 55 < bid 61.5: the
+    arbitrage state. Must be quarantined, not averaged."""
+    b = build([62.5, 31.25, 6.25],
+              bounds=[(None, 1.0), (1.0, 2.0), (2.0, None)])
+    crossed = BucketDepth(
+        None, 1.0,
+        yes_bids=[BookLevel(61.5, 100)],
+        yes_asks=[],
+        no_bids=[BookLevel(45, 100)],   # -> consolidated ask at 55, crossed
+        no_asks=[],
+    )
+    f = forecast_from_depth([crossed] + b[1:])
+    assert any("crossed" in w for w in f.warnings)
+
+
+def test_matches_quote_path_on_symmetric_books():
+    """On a symmetric mirrored book the depth path and the best-quote path
+    must agree on the probabilities (same mids, same residuals)."""
+    depth = build([62.5, 31.25, 6.25],
+                  bounds=[(None, 65000.0), (65000.0, 70000.0), (70000.0, None)])
+    quotes = [
+        BucketBook(lo, hi, m - 1, m + 1)
+        for (lo, hi), m in zip(
+            [(None, 65000.0), (65000.0, 70000.0), (70000.0, None)],
+            [62.5, 31.25, 6.25],
+        )
+    ]
+    fd = forecast_from_depth(depth)
+    fq = forecast_from_buckets(quotes)
+    for a, b in zip(fd.buckets, fq.buckets):
+        assert a.probability == pytest.approx(b.probability, abs=1e-9)
+    assert fd.value == pytest.approx(fq.value, abs=1e-6)

--- a/tests/test_forecast_live.py
+++ b/tests/test_forecast_live.py
@@ -22,6 +22,7 @@ plumbing between the SDK and the chain is connected the right way round.
 
 import os
 from collections import defaultdict
+from itertools import pairwise
 
 import pytest
 
@@ -69,7 +70,7 @@ def _tiles_the_line(members) -> bool:
     ordered = sorted(bounds, key=lambda b: (b[0] is not None, b[0]))
     if ordered[-1][1] is not None:
         return False
-    return all(a[1] == b[0] for a, b in zip(ordered, ordered[1:]))
+    return all(a[1] == b[0] for a, b in pairwise(ordered))
 
 
 def _discover_groups(client):
@@ -261,10 +262,23 @@ def test_bid_sign_convention_still_holds(live_client, live_forecast):
                 )
                 assert level.size > 0
 
-            if bids and best["best_bid"] is not None:
+            # A non-empty ladder and an absent best quote is itself a
+            # disagreement between the two node paths, which is what this test
+            # exists to catch. Skipping that case would hide it.
+            if bids:
+                assert best["best_bid"] is not None, (
+                    f"query {query_id} outcome={outcome}: get_order_book "
+                    f"returned {len(bids)} bid(s) but get_best_prices reports "
+                    "no best bid"
+                )
                 assert max(level.price for level in bids) == best["best_bid"]
                 checked += 1
-            if asks and best["best_ask"] is not None:
+            if asks:
+                assert best["best_ask"] is not None, (
+                    f"query {query_id} outcome={outcome}: get_order_book "
+                    f"returned {len(asks)} ask(s) but get_best_prices reports "
+                    "no best ask"
+                )
                 assert min(level.price for level in asks) == best["best_ask"]
                 checked += 1
 

--- a/tests/test_forecast_live.py
+++ b/tests/test_forecast_live.py
@@ -48,9 +48,28 @@ MIN_QUOTED_BUCKETS = 2
 
 
 def _tiles_the_line(members) -> bool:
-    """One bucket open below, one open above, at least one in between."""
-    types = [md["type"] for _, md, _ in members]
-    return len(members) >= 3 and types.count("below") == 1 and types.count("above") == 1
+    """A CONTIGUOUS bucket set: open below, open above, no gaps in between.
+
+    Counting the open ends is not enough. Markets can share a stream and a
+    settle time without tiling the line, and
+    ``test_buckets_are_ordered_and_tile_the_line`` asserts contiguity on
+    whatever this picks -- so letting a gapped group through here surfaces as a
+    FAILURE rather than the skip it should be.
+    """
+    if len(members) < 3:
+        return False
+
+    bounds = [b for _, _, b in members]
+    if sum(1 for lower, _ in bounds if lower is None) != 1:
+        return False
+    if sum(1 for _, upper in bounds if upper is None) != 1:
+        return False
+
+    # None sorts first, which is where the open-below bucket belongs.
+    ordered = sorted(bounds, key=lambda b: (b[0] is not None, b[0]))
+    if ordered[-1][1] is not None:
+        return False
+    return all(a[1] == b[0] for a, b in zip(ordered, ordered[1:]))
 
 
 def _discover_groups(client):
@@ -149,11 +168,16 @@ def _median_bucket(forecast):
     NOT the most probable bucket: with probabilities [0.40, 0.35, 0.25] the
     leader is the first, but the cumulative only reaches half way through the
     second, so that is where the median belongs.
+
+    The crossing test is STRICT so it agrees with the half-open [lower, upper)
+    bucket rule. On [0.50, 0.30, 0.20] the cumulative hits exactly 0.5 at the
+    end of bucket 1, and the median is the boundary value itself; that value
+    belongs to bucket 2, which is what a strict test returns.
     """
     running = 0.0
     for bucket in forecast.buckets:
         running += bucket.probability
-        if running >= 0.5:
+        if running > 0.5:
             return bucket
     return forecast.buckets[-1]
 
@@ -187,10 +211,12 @@ def test_value_falls_in_the_bucket_where_the_cdf_crosses_half(live_forecast):
         pytest.skip("median unresolvable from this market's strikes")
 
     bucket = _median_bucket(forecast)
+    # Half-open [lower, upper): the lower edge belongs to this bucket, the upper
+    # edge belongs to the next one.
     if bucket.lower is not None:
         assert forecast.value >= bucket.lower
     if bucket.upper is not None:
-        assert forecast.value <= bucket.upper
+        assert forecast.value < bucket.upper
 
 
 def test_band_brackets_the_value(live_forecast):
@@ -236,10 +262,10 @@ def test_bid_sign_convention_still_holds(live_client, live_forecast):
                 assert level.size > 0
 
             if bids and best["best_bid"] is not None:
-                assert max(l.price for l in bids) == best["best_bid"]
+                assert max(level.price for level in bids) == best["best_bid"]
                 checked += 1
             if asks and best["best_ask"] is not None:
-                assert min(l.price for l in asks) == best["best_ask"]
+                assert min(level.price for level in asks) == best["best_ask"]
                 checked += 1
 
     if not checked:

--- a/tests/test_forecast_live.py
+++ b/tests/test_forecast_live.py
@@ -1,0 +1,246 @@
+"""Live-network checks that the SDK reads real order books the right way round.
+
+Everything else in the forecast suite feeds the algorithm hand-written numbers,
+which proves the maths but cannot prove the SDK is reading the CHAIN correctly.
+If the node ever flipped the sign convention on bids, every one of those tests
+would still pass while the forecast silently inverted. That is the gap this
+file covers.
+
+Gated, because it needs the network and live markets carrying real orders. Run
+it with:
+
+    TN_LIVE_NODE_URL=https://gateway.mainnet.truf.network pytest tests/test_forecast_live.py
+
+All calls are view actions, so the signing key needs no funds and controls
+nothing; a throwaway is generated unless TN_LIVE_PRIVATE_KEY is set.
+
+These assert SHAPES, not numbers. Live books move minute to minute, so pinning
+an expected value would fail by tomorrow. Exact numbers belong in the unit
+tests. A wrong FORMULA will pass here quite happily — this only proves the
+plumbing between the SDK and the chain is connected the right way round.
+"""
+
+import os
+from collections import defaultdict
+
+import pytest
+
+from trufnetwork_sdk_py.market_buckets import bucket_bounds_from_market_data
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("TN_LIVE_NODE_URL"),
+    reason="live node not configured; set TN_LIVE_NODE_URL to run",
+)
+
+# Discovery costs one call per open market, so it is bounded. Mainnet carried
+# ~110 open markets when this was written; the cap is headroom, not a target.
+MAX_MARKETS_SCANNED = 500
+
+# Candidate groups to probe for quotes before giving up. A market can tile the
+# line perfectly and still have nobody quoting it, which is not a code defect,
+# so candidates are ranked by how much of the line is actually quoted rather
+# than by bucket count alone -- most open markets carry no orders at all.
+MAX_GROUPS_PROBED = 25
+
+# Below this many quoted buckets the forecast rests on residuals more than on
+# orders, which is not what this test is trying to exercise.
+MIN_QUOTED_BUCKETS = 2
+
+
+def _tiles_the_line(members) -> bool:
+    """One bucket open below, one open above, at least one in between."""
+    types = [md["type"] for _, md, _ in members]
+    return len(members) >= 3 and types.count("below") == 1 and types.count("above") == 1
+
+
+def _discover_groups(client):
+    """Every open market, grouped into candidate bucket sets.
+
+    A market's buckets share a data stream and a settlement time, which is
+    enough to reassemble them from chain data alone — no local config needed.
+    """
+    groups = defaultdict(list)
+    offset = 0
+    scanned = 0
+
+    while scanned < MAX_MARKETS_SCANNED:
+        page = client.list_markets(settled_filter=False, limit=100, offset=offset)
+        if not page:
+            break
+        for market in page:
+            scanned += 1
+            try:
+                info = client.get_market_info(market["id"])
+                query_components = info.get("query_components") or b""
+                if not query_components:
+                    continue
+                market_data = client.decode_market_data(query_components)
+                bounds = bucket_bounds_from_market_data(market_data)
+            except (ValueError, KeyError):
+                # Legacy or non-bucket markets: not what this test is about.
+                continue
+            key = (market_data["stream_id"], market["settle_time"])
+            groups[key].append((market["id"], market_data, bounds))
+        if len(page) < 100:
+            break
+        offset += 100
+
+    tiling = {k: v for k, v in groups.items() if _tiles_the_line(v)}
+    # Widest first: more buckets means more of the line actually quoted.
+    return sorted(tiling.values(), key=len, reverse=True)
+
+
+@pytest.fixture(scope="session")
+def live_client():
+    from eth_account import Account
+
+    from trufnetwork_sdk_py.client import TNClient
+
+    key = os.getenv("TN_LIVE_PRIVATE_KEY") or Account.create().key.hex()
+    return TNClient(os.environ["TN_LIVE_NODE_URL"], key)
+
+
+@pytest.fixture(scope="session")
+def live_forecast(live_client):
+    """A real market and the forecast it implies.
+
+    Skips rather than fails when the network has nothing quotable: an empty
+    book is a fact about the market that day, not a defect in this code.
+    """
+    candidates = _discover_groups(live_client)
+    if not candidates:
+        pytest.skip("no open market on this network currently tiles the line")
+
+    # One cheap call per bucket to find where the orders are. Ranking on this
+    # rather than on bucket count matters: most open markets tile the line
+    # perfectly and carry no orders whatsoever.
+    ranked = []
+    for members in candidates[:MAX_GROUPS_PROBED]:
+        query_ids = [query_id for query_id, _, _ in members]
+        quoted = 0
+        for query_id in query_ids:
+            best = live_client.get_best_prices(query_id, True)
+            if best["best_bid"] is not None or best["best_ask"] is not None:
+                quoted += 1
+        if quoted >= MIN_QUOTED_BUCKETS:
+            ranked.append((quoted, max(query_ids), query_ids))
+
+    if not ranked:
+        pytest.skip(
+            f"no market among {min(len(candidates), MAX_GROUPS_PROBED)} tiling "
+            f"candidates had {MIN_QUOTED_BUCKETS}+ quoted buckets"
+        )
+
+    # Most quoted first, then newest. Recency is only a tie-break: settled
+    # markets are already excluded, and on mainnet the newest markets are
+    # routinely the ones with no orders yet, so it is a poor primary signal.
+    ranked.sort(reverse=True)
+    for _, _, query_ids in ranked:
+        forecast = live_client.get_market_forecast(query_ids)
+        if forecast is not None:
+            return query_ids, forecast
+
+    pytest.skip("quoted markets found, but none yielded a usable forecast")
+
+
+def _median_bucket(forecast):
+    """The bucket where the implied CDF crosses 50%.
+
+    NOT the most probable bucket: with probabilities [0.40, 0.35, 0.25] the
+    leader is the first, but the cumulative only reaches half way through the
+    second, so that is where the median belongs.
+    """
+    running = 0.0
+    for bucket in forecast.buckets:
+        running += bucket.probability
+        if running >= 0.5:
+            return bucket
+    return forecast.buckets[-1]
+
+
+def test_a_real_market_produces_a_forecast(live_forecast):
+    query_ids, forecast = live_forecast
+
+    assert len(query_ids) >= 3
+    assert forecast.value == forecast.value, "value is NaN"
+    assert forecast.method in {"rank", "discrete"}
+    assert forecast.value_basis in {"interior", "tail", "unresolved"}
+
+
+def test_probabilities_form_a_distribution(live_forecast):
+    _, forecast = live_forecast
+
+    probabilities = [b.probability for b in forecast.buckets]
+    assert all(0.0 <= p <= 1.0 for p in probabilities)
+    assert sum(probabilities) == pytest.approx(1.0)
+
+
+def test_value_falls_in_the_bucket_where_the_cdf_crosses_half(live_forecast):
+    """The point estimate is the median, so it must land in the median bucket.
+
+    This is the assertion that would catch a bounds-derivation or ordering
+    mistake: get the buckets in the wrong order and the value lands in the
+    wrong one.
+    """
+    _, forecast = live_forecast
+    if forecast.value_basis == "unresolved":
+        pytest.skip("median unresolvable from this market's strikes")
+
+    bucket = _median_bucket(forecast)
+    if bucket.lower is not None:
+        assert forecast.value >= bucket.lower
+    if bucket.upper is not None:
+        assert forecast.value <= bucket.upper
+
+
+def test_band_brackets_the_value(live_forecast):
+    _, forecast = live_forecast
+    if forecast.p10 is None or forecast.p90 is None:
+        pytest.skip("band unresolvable from this market's strikes")
+
+    assert forecast.p10 <= forecast.value <= forecast.p90
+    assert forecast.margin_of_error > 0
+
+
+def test_buckets_are_ordered_and_tile_the_line(live_forecast):
+    """Assembly must hand the algorithm an ascending, gap-free ladder."""
+    _, forecast = live_forecast
+    buckets = forecast.buckets
+
+    assert buckets[0].lower is None, "bottom bucket should be open below"
+    assert buckets[-1].upper is None, "top bucket should be open above"
+    for lower, upper in zip(buckets, buckets[1:]):
+        assert lower.upper == upper.lower, "gap or overlap between buckets"
+
+
+def test_bid_sign_convention_still_holds(live_client, live_forecast):
+    """The canary.
+
+    get_order_book marks bids with a NEGATIVE price; get_best_prices reports
+    the same bid as POSITIVE. Two independent node paths for one fact, so if
+    either convention ever changes they stop agreeing here — loudly — instead
+    of silently inverting every one-sided bucket in the forecast.
+    """
+    query_ids, _ = live_forecast
+
+    checked = 0
+    for query_id in query_ids:
+        for outcome in (True, False):
+            bids, asks = live_client._order_book_ladders(query_id, outcome)
+            best = live_client.get_best_prices(query_id, outcome)
+
+            for level in bids + asks:
+                assert 0 < level.price < 100, (
+                    f"price {level.price} outside the 1-99 cent convention"
+                )
+                assert level.size > 0
+
+            if bids and best["best_bid"] is not None:
+                assert max(l.price for l in bids) == best["best_bid"]
+                checked += 1
+            if asks and best["best_ask"] is not None:
+                assert min(l.price for l in asks) == best["best_ask"]
+                checked += 1
+
+    if not checked:
+        pytest.skip("no resting orders to cross-check the sign convention against")

--- a/tests/test_market_buckets.py
+++ b/tests/test_market_buckets.py
@@ -216,6 +216,26 @@ def test_buckets_from_two_different_markets_are_rejected():
         fake_client(both).get_market_forecast(list(both))
 
 
+def test_markets_differing_only_in_the_time_they_observe_are_rejected():
+    """The case settle_time alone cannot see: same provider, same stream, same
+    settlement, but observing the stream a day apart.
+
+    The stub supplies ``timestamp`` because the committed Go bindings do not
+    emit it yet; this pins the comparison so it works the moment they do.
+    """
+    later = {
+        query_id + 200: ({**market_data, "timestamp": 1700086400}, quotes)
+        for query_id, (market_data, quotes) in MSFT_MARKETS.items()
+    }
+    earlier = {
+        query_id: ({**market_data, "timestamp": 1700000000}, quotes)
+        for query_id, (market_data, quotes) in MSFT_MARKETS.items()
+    }
+    both = {**earlier, **later}
+    with pytest.raises(ValueError, match="different event"):
+        fake_client(both).get_market_forecast(list(both))
+
+
 def test_each_of_those_sets_still_forecasts_on_its_own():
     """The identity check must reject the mixture without rejecting either half."""
     assert fake_client().get_market_forecast(list(MSFT_MARKETS)) is not None

--- a/tests/test_market_buckets.py
+++ b/tests/test_market_buckets.py
@@ -236,6 +236,22 @@ def test_markets_differing_only_in_the_time_they_observe_are_rejected():
         fake_client(both).get_market_forecast(list(both))
 
 
+def test_markets_differing_only_in_the_block_they_freeze_are_rejected():
+    """`frozen_at` is the other query field settle_time cannot see: the same
+    question asked of pinned data and of latest data is two different queries."""
+    pinned = {
+        query_id + 300: ({**market_data, "frozen_at": 987654}, quotes)
+        for query_id, (market_data, quotes) in MSFT_MARKETS.items()
+    }
+    latest = {
+        query_id: ({**market_data, "frozen_at": None}, quotes)
+        for query_id, (market_data, quotes) in MSFT_MARKETS.items()
+    }
+    both = {**latest, **pinned}
+    with pytest.raises(ValueError, match="different event"):
+        fake_client(both).get_market_forecast(list(both))
+
+
 def test_each_of_those_sets_still_forecasts_on_its_own():
     """The identity check must reject the mixture without rejecting either half."""
     assert fake_client().get_market_forecast(list(MSFT_MARKETS)) is not None

--- a/tests/test_market_buckets.py
+++ b/tests/test_market_buckets.py
@@ -43,6 +43,32 @@ def test_equals_market_is_target_plus_minus_tolerance():
     assert lower < upper
 
 
+def test_non_finite_thresholds_are_rejected():
+    """float() accepts these without complaint; left alone they surface as a NaN
+    forecast rather than as an unreadable market."""
+    for value in ("nan", "inf", "+inf", "-inf"):
+        with pytest.raises(ValueError, match="not finite"):
+            bucket_bounds_from_market_data({"type": "below", "thresholds": [value]})
+
+
+def test_inverted_or_empty_between_bucket_is_rejected():
+    """Bounds are half-open [lower, upper): equal bounds are empty and inverted
+    ones can never hold an outcome."""
+    for thresholds in (["4.62", "4.33"], ["4.33", "4.33"]):
+        with pytest.raises(ValueError, match="lower < upper"):
+            bucket_bounds_from_market_data(
+                {"type": "between", "thresholds": thresholds}
+            )
+
+
+def test_non_positive_equals_tolerance_is_rejected():
+    for tolerance in ("0", "-0.10"):
+        with pytest.raises(ValueError, match="positive tolerance"):
+            bucket_bounds_from_market_data(
+                {"type": "equals", "thresholds": ["5.25", tolerance]}
+            )
+
+
 def test_unknown_market_type_is_rejected():
     with pytest.raises(ValueError, match="cannot derive bucket bounds"):
         bucket_bounds_from_market_data({"type": "unknown", "thresholds": []})
@@ -250,6 +276,44 @@ def test_markets_differing_only_in_the_block_they_freeze_are_rejected():
     both = {**latest, **pinned}
     with pytest.raises(ValueError, match="different event"):
         fake_client(both).get_market_forecast(list(both))
+
+
+def test_markets_differing_only_in_their_bridge_are_rejected():
+    """The bridge is the one identity field outside the query components: it is
+    a create_market argument, so an identical question can be collateralised two
+    ways. Those are separate markets with separate books."""
+    other_bridge = {
+        query_id + 500: (market_data, quotes)
+        for query_id, (market_data, quotes) in MSFT_MARKETS.items()
+    }
+    both = {**MSFT_MARKETS, **other_bridge}
+    client = fake_client(both)
+    client.get_market_info = lambda query_id: {
+        "query_components": str(query_id).encode(),
+        "bridge": "eth_truf" if query_id >= 500 else "eth_usdc",
+    }
+    with pytest.raises(ValueError, match="different event"):
+        client.get_market_forecast(list(both))
+
+
+def test_unreadable_query_timestamp_is_rejected():
+    """A None timestamp compares equal across buckets, so two malformed markets
+    would collide on it and match each other. The key being ABSENT is different
+    -- that is the current bindings not emitting it, which every other test in
+    this file relies on."""
+    unreadable = {
+        query_id: ({**market_data, "timestamp": None}, quotes)
+        for query_id, (market_data, quotes) in MSFT_MARKETS.items()
+    }
+    with pytest.raises(ValueError, match="no readable query timestamp"):
+        fake_client(unreadable).get_market_forecast(list(unreadable))
+
+
+def test_absent_timestamp_key_is_not_treated_as_unreadable():
+    """Today's bindings emit five keys and no timestamp at all. That must keep
+    working until they are rebuilt."""
+    assert "timestamp" not in MSFT_MARKETS[101][0]
+    assert fake_client().get_market_forecast(list(MSFT_MARKETS)) is not None
 
 
 def test_each_of_those_sets_still_forecasts_on_its_own():

--- a/tests/test_market_buckets.py
+++ b/tests/test_market_buckets.py
@@ -69,6 +69,17 @@ def test_non_positive_equals_tolerance_is_rejected():
             )
 
 
+def test_collapsed_or_overflowing_equals_bounds_are_rejected():
+    """A positive tolerance is not enough. Absorbed by a large target it leaves
+    both edges on the same value, and near the float limits the sum overflows."""
+    assert 1e300 - 1e-300 == 1e300 + 1e-300, "the collapse, demonstrated"
+    for thresholds in (["1e300", "1e-300"], ["1.7e308", "1.7e308"]):
+        with pytest.raises(ValueError, match="usable bucket"):
+            bucket_bounds_from_market_data(
+                {"type": "equals", "thresholds": thresholds}
+            )
+
+
 def test_unknown_market_type_is_rejected():
     with pytest.raises(ValueError, match="cannot derive bucket bounds"):
         bucket_bounds_from_market_data({"type": "unknown", "thresholds": []})

--- a/tests/test_market_buckets.py
+++ b/tests/test_market_buckets.py
@@ -192,6 +192,36 @@ def test_single_bucket_is_rejected():
         fake_client().get_market_forecast([103])
 
 
+def test_duplicate_query_ids_are_rejected():
+    """A repeated bucket would have its probability counted twice, quietly
+    reshaping the distribution rather than failing."""
+    with pytest.raises(ValueError, match="duplicate"):
+        fake_client().get_market_forecast([101, 102, 103, 103])
+
+
+# A second, independently valid bucket set, on a different stream. Each set
+# forecasts fine alone; the two together describe unrelated events.
+OTHER_MARKETS = {
+    query_id + 100: ({**market_data, "stream_id": "other"}, quotes)
+    for query_id, (market_data, quotes) in MSFT_MARKETS.items()
+}
+
+
+def test_buckets_from_two_different_markets_are_rejected():
+    """Normalising across two events would divide one market's probabilities by
+    the other's total and return a confident number about nothing. Both sets are
+    individually valid, so nothing but the identity check catches this."""
+    both = {**MSFT_MARKETS, **OTHER_MARKETS}
+    with pytest.raises(ValueError, match="different event"):
+        fake_client(both).get_market_forecast(list(both))
+
+
+def test_each_of_those_sets_still_forecasts_on_its_own():
+    """The identity check must reject the mixture without rejecting either half."""
+    assert fake_client().get_market_forecast(list(MSFT_MARKETS)) is not None
+    assert fake_client(OTHER_MARKETS).get_market_forecast(list(OTHER_MARKETS)) is not None
+
+
 def test_market_without_query_components_is_rejected():
     """Legacy markets carry no bounds, and guessing them would be worse than
     failing."""

--- a/tests/test_market_buckets.py
+++ b/tests/test_market_buckets.py
@@ -1,0 +1,204 @@
+"""Tests for the SDK-side glue around the forecast algorithm.
+
+The algorithm itself is a verbatim mirror of upstream and is covered by
+test_forecast.py / test_forecast_depth.py. What is tested here is only what
+the SDK adds: deriving bucket bounds from decoded market data, and assembling
+a market's order books into a forecast.
+"""
+
+import pytest
+
+from trufnetwork_sdk_py.forecast import BookLevel, BucketDepth, forecast_from_depth
+from trufnetwork_sdk_py.market_buckets import bucket_bounds_from_market_data
+
+# --- bucket bounds from decoded market data -----------------------------------
+
+
+def test_below_market_is_the_open_bottom_bucket():
+    assert bucket_bounds_from_market_data(
+        {"type": "below", "thresholds": ["4.04"]}
+    ) == (None, 4.04)
+
+
+def test_above_market_is_the_open_top_bucket():
+    assert bucket_bounds_from_market_data(
+        {"type": "above", "thresholds": ["4.92"]}
+    ) == (4.92, None)
+
+
+def test_between_market_is_an_interior_bucket():
+    assert bucket_bounds_from_market_data(
+        {"type": "between", "thresholds": ["4.33", "4.62"]}
+    ) == (4.33, 4.62)
+
+
+def test_equals_market_is_target_plus_minus_tolerance():
+    """Its thresholds are (target, tolerance), NOT (lower, upper). Reading them
+    positionally the way `between` is read would yield the bucket (5.25, 0.10):
+    inverted, and silently wrong rather than loud."""
+    lower, upper = bucket_bounds_from_market_data(
+        {"type": "equals", "thresholds": ["5.25", "0.10"]}
+    )
+    assert (lower, upper) == pytest.approx((5.15, 5.35))
+    assert lower < upper
+
+
+def test_unknown_market_type_is_rejected():
+    with pytest.raises(ValueError, match="cannot derive bucket bounds"):
+        bucket_bounds_from_market_data({"type": "unknown", "thresholds": []})
+
+
+def test_missing_thresholds_are_rejected():
+    with pytest.raises(ValueError, match="threshold"):
+        bucket_bounds_from_market_data({"type": "between", "thresholds": ["4.33"]})
+
+
+# --- client assembly ----------------------------------------------------------
+
+# The live mainnet MSFT book, as five separate markets. Bounds are carried in
+# each bucket's own query_components, exactly as on chain. Quotes are
+# (yes_bid, yes_ask) in cents; None means nothing resting on that side.
+MSFT_MARKETS = {
+    101: ({"type": "below", "thresholds": ["4.04"]}, (1, None)),
+    102: ({"type": "between", "thresholds": ["4.04", "4.33"]}, (16, 28)),
+    103: ({"type": "between", "thresholds": ["4.33", "4.62"]}, (44, 56)),
+    104: ({"type": "between", "thresholds": ["4.62", "4.92"]}, (9, 21)),
+    105: ({"type": "above", "thresholds": ["4.92"]}, (1, None)),
+}
+
+# Big enough that even a 1c level clears DEPTH_MIN_SIDE_NOTIONAL_USD, so the
+# dust floor never silently empties a side these tests meant to be quoted.
+SIZE = 1000
+
+
+def order_book(bid, ask):
+    """SDK order-book rows: bids carry a NEGATIVE price, asks a positive one."""
+    rows = []
+    if bid is not None:
+        rows.append({"price": -bid, "amount": SIZE})
+    if ask is not None:
+        rows.append({"price": ask, "amount": SIZE})
+    return rows
+
+
+def fake_client(markets=MSFT_MARKETS, query_components=True, no_books=None):
+    """A TNClient whose network calls are stubbed.
+
+    Built with __new__ so no connection is attempted: this exercises the
+    assembly logic (bounds, sorting, layout checks) with no node.
+    """
+    from trufnetwork_sdk_py.client import TNClient
+
+    client = TNClient.__new__(TNClient)
+    client.get_market_info = lambda query_id: {
+        "query_components": str(query_id).encode() if query_components else b""
+    }
+    client.decode_market_data = lambda qc: markets[int(qc)][0]
+
+    def _order_book(query_id, outcome):
+        if outcome:
+            return order_book(*markets[query_id][1])
+        return (no_books or {}).get(query_id, [])
+
+    client.get_order_book = _order_book
+    return client
+
+
+def depths(markets=MSFT_MARKETS):
+    """The same books, built directly, to compare the assembled path against."""
+    out = []
+    for query_id, (market_data, (bid, ask)) in sorted(markets.items()):
+        lower, upper = bucket_bounds_from_market_data(market_data)
+        out.append(
+            BucketDepth(
+                lower=lower,
+                upper=upper,
+                yes_bids=[BookLevel(bid, SIZE)] if bid is not None else [],
+                yes_asks=[BookLevel(ask, SIZE)] if ask is not None else [],
+                query_id=query_id,
+            )
+        )
+    return out
+
+
+def test_client_forecast_matches_a_direct_call():
+    """Assembly must not change the answer: same books in, same number out."""
+    assembled = fake_client().get_market_forecast(list(MSFT_MARKETS))
+    direct = forecast_from_depth(depths())
+
+    assert assembled.value == pytest.approx(direct.value)
+    assert assembled.p10 == pytest.approx(direct.p10)
+    assert assembled.p90 == pytest.approx(direct.p90)
+    assert [b.probability for b in assembled.buckets] == pytest.approx(
+        [b.probability for b in direct.buckets]
+    )
+
+
+def test_forecast_lands_inside_the_leading_bucket():
+    """The live MSFT book: the tight 44-56 bucket leads, so the value belongs
+    inside it."""
+    f = fake_client().get_market_forecast(list(MSFT_MARKETS))
+
+    probs = [b.probability for b in f.buckets]
+    assert probs[2] == max(probs)
+    assert 4.33 <= f.value <= 4.62
+
+
+def test_no_side_liquidity_is_consolidated_into_the_estimate():
+    """A resting BUY NO at p is hittable by a BUY YES at 100-p, so NO depth is
+    executable YES depth. Adding a NO bid must therefore supply the missing YES
+    ask and stop the bucket reading as one-sided."""
+    bare = fake_client().get_market_forecast(list(MSFT_MARKETS))
+    # A NO bid at 84 mirrors to a YES ask at 16 on the open bottom bucket.
+    with_no = fake_client(
+        no_books={101: [{"price": -84, "amount": SIZE}]}
+    ).get_market_forecast(list(MSFT_MARKETS))
+
+    assert bare.buckets[0].one_sided
+    assert not with_no.buckets[0].one_sided
+    assert with_no.buckets[0].confidence > bare.buckets[0].confidence
+
+
+def test_query_ids_may_be_given_in_any_order():
+    """Buckets are sorted by bound here, so callers need not track which
+    query_id is the bottom of the line."""
+    ordered = fake_client().get_market_forecast([101, 102, 103, 104, 105])
+    shuffled = fake_client().get_market_forecast([103, 105, 101, 104, 102])
+
+    assert shuffled.value == pytest.approx(ordered.value)
+    assert [b.query_id for b in shuffled.buckets] == [101, 102, 103, 104, 105]
+
+
+def test_gap_in_the_bucket_layout_is_reported_not_hidden():
+    """A market missing an interior bucket still gets an estimate, but the
+    caller must be able to see that the line was not fully tiled."""
+    f = fake_client().get_market_forecast([101, 102, 104, 105])
+
+    assert f is not None
+    assert any("gap" in w for w in f.warnings)
+
+
+def test_layout_warning_when_the_line_is_not_open_ended():
+    """Interior buckets only: nothing covers the tails, so the mass beyond them
+    is unrepresented and the caller should know."""
+    f = fake_client().get_market_forecast([102, 103, 104])
+
+    assert any("not open below" in w for w in f.warnings)
+    assert any("not open above" in w for w in f.warnings)
+
+
+def test_single_bucket_is_rejected():
+    with pytest.raises(ValueError, match="at least 2"):
+        fake_client().get_market_forecast([103])
+
+
+def test_market_without_query_components_is_rejected():
+    """Legacy markets carry no bounds, and guessing them would be worse than
+    failing."""
+    with pytest.raises(ValueError, match="query_components"):
+        fake_client(query_components=False).get_market_forecast([101, 102])
+
+
+def test_unquoted_market_yields_no_forecast():
+    dead = {qid: (md, (None, None)) for qid, (md, _) in MSFT_MARKETS.items()}
+    assert fake_client(dead).get_market_forecast(list(dead)) is None


### PR DESCRIPTION
Prediction markets price RANGES. A five-bucket EPS market says "34% chance EPS lands between $2.06 and $2.21"; it never says "EPS will be $2.14". This adds the inverse: given the order books across every bucket of one market, produce the single number they collectively imply and the band around it.

## What

- `trufnetwork_sdk_py.forecast` — the algorithm, as pure functions with no I/O: `forecast_from_depth` (preferred), `forecast_from_buckets`, and the `BucketDepth` / `BookLevel` / `BucketBook` / `MarketForecast` types.
- `TNClient.get_market_forecast(query_ids)` — fetches the books for a market's buckets and returns the forecast.
- `trufnetwork_sdk_py.market_buckets.bucket_bounds_from_market_data` — turns decoded market data into a bucket's `(lower, upper)` bounds.
- API reference section covering all of the above.

## Why

The algorithm is validated against live mainnet books in truflation/prediction-bots, where it drives quoting. Callers of this SDK — the indexer, dashboards, anything reading a market — otherwise have to reimplement it or go without.

## How

`forecast.py` is a VERBATIM copy of
truflation/prediction-bots@21fe4f3 (`market-maker-bot/src/market_maker_bot/ forecast.py`), carrying only an added provenance header. That is deliberate. The module is numerics that were tuned against real books and it is still moving fast — three substantive revisions in the past week — so re-syncing has to stay a `diff` rather than a re-transcription. Style was left un-adapted for the same reason. SDK-specific glue lives in `market_buckets.py` instead of being added to the mirrored file, so the diff stays clean.

`get_market_forecast` reads both the YES and NO ladders per bucket. On this venue a resting BUY NO at p is hittable by a BUY YES at 100-p (mint match), so NO liquidity is executable YES liquidity; ignoring it discards real quotes. That costs two order-book reads per bucket.

## Notes for callers

`margin_of_error` is half the P10..P90 band — how uncertain the OUTCOME is, not how tightly the book pins the estimate. It is large by design (~0.24 against a value of ~2.14 on a live EPS market). The `value_basis` / `p10_basis` / `p90_basis` flags say whether a number was read between real strikes or supplied by the tail model for an open-ended outer bucket.

## Testing

57 offline tests, ported from upstream alongside the module, plus SDK-side tests for bounds derivation and client assembly.

`tests/test_forecast_live.py` adds an env-gated check against a real network (`TN_LIVE_NODE_URL`), skipped by default. Unit tests feed the algorithm hand-written numbers and so cannot catch the SDK reading the chain wrongly; its central assertion cross-checks `get_order_book`'s negative-price bid convention against `get_best_prices`, which reports the same bid positive. If either convention changes, that fails loudly instead of silently inverting every one-sided bucket.

Verified end-to-end against mainnet: the discovered NVDA EPS market (query_ids 419-423) forecasts 2.1363 with a 1.9058..2.3792 band, agreeing with an independent top-of-book read to within 0.002.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added market-implied forecasting from prediction-market quotes and order-book depth.
  * Added forecast values, uncertainty bands, bucket probabilities, confidence indicators, warnings, and serialization.
  * Added client support for retrieving forecasts across market buckets.
  * Added utilities for deriving bucket bounds from market metadata.
* **Documentation**
  * Added API documentation and usage examples for forecasting.
* **Tests**
  * Added coverage for quote-based, depth-based, live-market, and edge-case forecasting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->