### PR TITLE
chore: bump sdk-go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558
-	github.com/trufnetwork/sdk-go v0.7.4-0.20260804082214-38a6f5396c5c
+	github.com/trufnetwork/sdk-go v0.7.4
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.sum
+++ b/go.sum
@@ -60,10 +60,8 @@ github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558 h1:I49YGUiU
 github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558 h1:m7a9HITFMXJF22QznIKoAdeiH8eZxWPU8IRzgcyNMo8=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
-github.com/trufnetwork/sdk-go v0.7.3-0.20260623101902-a88c54ac6abb h1:NyKYWkkmeShfSR+2FjAg78s+k0LY5A95Yayh4H+yPjo=
-github.com/trufnetwork/sdk-go v0.7.3-0.20260623101902-a88c54ac6abb/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
-github.com/trufnetwork/sdk-go v0.7.4-0.20260804082214-38a6f5396c5c h1:PhmC1YDj6d6USgzq3WrkLiKPpYe51beJMEhO+zVkgbQ=
-github.com/trufnetwork/sdk-go v0.7.4-0.20260804082214-38a6f5396c5c/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
+github.com/trufnetwork/sdk-go v0.7.4 h1:atGfhl//mU2IjUsu6NqE6lzJtXGqnymm/EX/W4ULryU=
+github.com/trufnetwork/sdk-go v0.7.4/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=


### PR DESCRIPTION
`go.mod` pinned sdk-go at `v0.7.4-0.20260804082214-38a6f5396c5c`, a pseudo-version of what was then an untagged commit. sdk-go has since tagged `v0.7.4` at that exact commit, so this swaps the pseudo-version for the release.

Same code either way — both lines carry the identical `go.mod` hash `CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=`. The point is that a published wheel should depend on a released version rather than a commit, and `go get -u` no longer sees the pin as a pre-release sorting below `v0.7.4`.

`go mod tidy` drops the two stale pseudo-version entries from `go.sum` and adds nothing else.

## Testing

Bindings rebuilt against the tag; 69 offline tests pass (`test_forecast`, `test_forecast_depth`, `test_market_buckets`). `go build ./...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TrufNetwork SDK dependency to a stable release, improving version consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->