### PR TITLE
feat: read consolidated order books from Python

### DIFF
--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -21,6 +21,7 @@ import (
 	kwillog "github.com/trufnetwork/kwil-db/core/log"
 	kwilTypes "github.com/trufnetwork/kwil-db/core/types"
 	"github.com/trufnetwork/sdk-go/core/contractsapi"
+	"github.com/trufnetwork/sdk-go/core/forecast"
 	"github.com/trufnetwork/sdk-go/core/tnclient"
 	"github.com/trufnetwork/sdk-go/core/types"
 	"github.com/trufnetwork/sdk-go/core/util"
@@ -2475,6 +2476,74 @@ func GetBestPrices(client *tnclient.Client, queryID int, outcome bool) (string, 
 	}
 
 	return string(jsonBytes), nil
+}
+
+// GetConsolidatedOrderBook returns one outcome's book with the opposite
+// outcome's quotes folded in.
+//
+// A binary market's two books are two views of one position, and the matching
+// engine fills across them. A resting SELL NO at 93c is a standing BID for YES
+// at 7c: a trader hits it by SELLING YES, both sides sell, and the chain burns
+// the share pair. GetMarketDepth on the YES outcome cannot show that quote, so
+// the market looks thinner than it is.
+//
+// In the YES frame:
+//
+//	consolidated bids = YES bids + (100 - p for every NO ask)
+//	consolidated asks = YES asks + (100 - p for every NO bid)
+//
+// The folding rule lives in sdk-go, so Python, Go and TypeScript agree on what
+// a market's executable ladder is.
+func GetConsolidatedOrderBook(client *tnclient.Client, queryID int, outcome bool) (string, error) {
+	ctx := context.Background()
+
+	orderBook, err := client.LoadOrderBook()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to load order book")
+	}
+
+	book, err := orderBook.GetConsolidatedOrderBook(ctx, types.GetConsolidatedOrderBookInput{
+		QueryID: queryID,
+		Outcome: outcome,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get consolidated order book")
+	}
+
+	consolidated := map[string]any{
+		"query_id":   book.QueryID,
+		"outcome":    book.Outcome,
+		"bids":       consolidatedLevels(book.Bids),
+		"asks":       consolidatedLevels(book.Asks),
+		"is_crossed": book.IsCrossed,
+	}
+
+	jsonBytes, err := json.Marshal(consolidated)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal consolidated order book")
+	}
+
+	return string(jsonBytes), nil
+}
+
+// consolidatedLevels renders one side of a consolidated ladder for JSON.
+//
+// Native and inverse are carried separately rather than only as their sum. Mint
+// and burn matches fire only when the two prices sum to exactly 100, while a
+// direct same-outcome match crosses, so one order fills every native level past
+// its limit plus exactly ONE inverse level. Anything quoting a fill needs the
+// split to get that right.
+func consolidatedLevels(levels []forecast.ConsolidatedLevel) []map[string]any {
+	out := make([]map[string]any, len(levels))
+	for i, level := range levels {
+		out[i] = map[string]any{
+			"price":   level.Price,
+			"total":   level.Total,
+			"native":  level.Native,
+			"inverse": level.Inverse,
+		}
+	}
+	return out
 }
 
 // GetUserCollateral returns caller's total locked collateral value

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1444,6 +1444,72 @@ Get aggregated order book depth for a market outcome.
 
 **Returns:** List of depth levels with aggregated amounts at each price.
 
+#### `client.get_consolidated_order_book(query_id, outcome=True) -> ConsolidatedOrderBook`
+
+Get one outcome's book with the opposite outcome's quotes folded in.
+
+**Parameters:**
+- `query_id: int` - Market ID
+- `outcome: bool` - The outcome the prices are framed in, True=YES. The
+  NO-framed book is the YES-framed book reflected, so one call answers either
+  tab.
+
+`get_market_depth` returns one outcome's ladder, but a binary market's two books
+are two views of one position and the matching engine fills across them. A
+resting SELL NO at 93c is a standing **bid** for YES at 7c: a trader hits it by
+**selling** YES, both sides sell, and the chain burns the share pair. Read only
+the YES book and that quote is invisible.
+
+In the YES frame:
+
+```text
+consolidated bids = YES bids + (100 - p for every NO ask)
+consolidated asks = YES asks + (100 - p for every NO bid)
+```
+
+The sides swap. A NO ask arrives as a YES bid, because hitting it means both
+parties sell and the share pair burns; hitting a consolidated ask means both buy
+and a pair mints.
+
+**Returns:** A `ConsolidatedOrderBook` with `bids` best (highest) first and
+`asks` best (lowest) first.
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `query_id` | `int` | The market this book belongs to |
+| `outcome` | `bool` | Which side the prices are framed in |
+| `bids`, `asks` | `list[ConsolidatedLevel]` | The executable ladder, best first |
+| `is_crossed` | `bool` | Whether the best bid sits at or above the best ask |
+
+Each `ConsolidatedLevel` carries `price`, `total`, `native` and `inverse`.
+`native` rests in this outcome's own book and fills as a direct match; `inverse`
+rests in the opposite outcome's book at `100 - price`.
+
+**Example:**
+```python
+book = client.get_consolidated_order_book(query_id=419)
+for level in book["asks"]:
+    print(f"{level['price']:.0f}c: {level['total']:.0f} shares "
+          f"({level['native']:.0f} direct, {level['inverse']:.0f} mint)")
+```
+
+**This is not a sweepable ladder.** A direct same-outcome match crosses prices,
+but mint and burn fire only when the two prices sum to exactly 100. So one order
+fills every native level past its limit plus exactly **one** inverse level.
+Walking these levels the way you would walk `get_market_depth` quotes fills the
+chain will not produce, which is why each level keeps `native` and `inverse`
+separate rather than only their sum.
+
+A consolidated book can also sit crossed indefinitely, which `is_crossed`
+reports: a YES bid at 61 against a NO bid at 45 shows a bid at 61 over an ask at
+55, and 61 + 45 is not 100 so nothing matches. Render it rather than treating it
+as bad data.
+
+Costs one `get_full_market_depth` read, so both sides are one snapshot of the
+chain and `is_crossed` describes a state the book was really in. Requires a node
+carrying that action. The folding itself runs in sdk-go, so Python, Go and
+TypeScript agree on what a market's executable ladder is.
+
 ### Market Forecasting
 
 Prediction markets price **ranges**, not values. A five-bucket EPS market says

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558
-	github.com/trufnetwork/sdk-go v0.7.4
+	github.com/trufnetwork/sdk-go v0.7.5-0.20260806143829-879be314b9a4
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558 h1:I49YGUiU
 github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558 h1:m7a9HITFMXJF22QznIKoAdeiH8eZxWPU8IRzgcyNMo8=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
-github.com/trufnetwork/sdk-go v0.7.4 h1:atGfhl//mU2IjUsu6NqE6lzJtXGqnymm/EX/W4ULryU=
-github.com/trufnetwork/sdk-go v0.7.4/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
+github.com/trufnetwork/sdk-go v0.7.5-0.20260806143829-879be314b9a4 h1:Ew5cITYYgOw2GhDhTVZz5zjVQFxStTiw3JDaWA97l0I=
+github.com/trufnetwork/sdk-go v0.7.5-0.20260806143829-879be314b9a4/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -254,7 +254,37 @@ class UserPosition(TypedDict):
 class DepthLevel(TypedDict):
     """Market depth at price level"""
     price: int
-    total_amount: int
+    buy_volume: int
+    sell_volume: int
+
+
+class ConsolidatedLevel(TypedDict):
+    """One price level of a consolidated order book, in the requested frame.
+
+    ``native`` rests in this outcome's own book and fills as a direct match.
+    ``inverse`` rests in the opposite outcome's book at ``100 - price`` and
+    fills by minting a share pair on the ask side or burning one on the bid
+    side. ``total`` is their sum.
+    """
+    price: float
+    total: float
+    native: float
+    inverse: float
+
+
+class ConsolidatedOrderBook(TypedDict):
+    """One outcome's book with the opposite outcome's quotes folded in.
+
+    ``is_crossed`` reports the best bid sitting at or above the best ask. That
+    is a real state a consolidated book can hold indefinitely, not bad data:
+    a YES bid at 61 and a NO bid at 45 read as a bid at 61 over an ask at 55,
+    and the engine never matches them because 61 + 45 is not 100.
+    """
+    query_id: int
+    outcome: bool
+    bids: list[ConsolidatedLevel]
+    asks: list[ConsolidatedLevel]
+    is_crossed: bool
 
 
 class BestPrices(TypedDict):
@@ -2800,6 +2830,62 @@ class TNClient:
             return []
 
         return cast(list[DepthLevel], json.loads(json_str))
+
+    def get_consolidated_order_book(
+        self, query_id: int, outcome: bool = True
+    ) -> ConsolidatedOrderBook:
+        """Get one outcome's book with the opposite outcome's quotes folded in.
+
+        ``get_market_depth`` returns a single outcome's ladder, but a binary
+        market's two books are two views of one position and the matching
+        engine fills across them. A resting SELL NO at 93c is a standing BID
+        for YES at 7c: a trader hits it by SELLING YES, both sides sell, and
+        the chain burns the share pair. Read only the YES book and that quote
+        is invisible, which makes the market look thinner than it is.
+
+        So, in the YES frame::
+
+            consolidated bids = YES bids + (100 - p for every NO ask)
+            consolidated asks = YES asks + (100 - p for every NO bid)
+
+        The sides swap. A NO ask arrives as a YES bid, because hitting it means
+        both parties sell and the pair burns; hitting a consolidated ask means
+        both buy and a pair mints.
+
+        **This is not a sweepable ladder.** A direct same-outcome match crosses
+        prices, but mint and burn fire only when the two prices sum to exactly
+        100. One order therefore fills every native level past its limit plus
+        exactly ONE inverse level, so walking these levels the way you would
+        walk ``get_market_depth`` quotes fills the chain will not produce. That
+        is why each level keeps ``native`` and ``inverse`` separate rather than
+        only their sum.
+
+        Args:
+            query_id: The market to read.
+            outcome: The outcome the prices are framed in, True=YES. The
+                NO-framed book is the YES-framed book reflected, so one call
+                answers either tab.
+
+        Returns:
+            A ``ConsolidatedOrderBook`` with ``bids`` best (highest) first and
+            ``asks`` best (lowest) first.
+
+        Cost is one ``get_full_market_depth`` read, so both sides are one
+        snapshot of the chain and ``is_crossed`` describes a state the book was
+        really in. Requires a node carrying that action.
+        """
+        json_str = truf_sdk.GetConsolidatedOrderBook(self.client, query_id, outcome)
+
+        if not json_str:
+            return {
+                "query_id": query_id,
+                "outcome": outcome,
+                "bids": [],
+                "asks": [],
+                "is_crossed": False,
+            }
+
+        return cast(ConsolidatedOrderBook, json.loads(json_str))
 
     def get_best_prices(self, query_id: int, outcome: bool) -> BestPrices:
         """Get current bid/ask spread."""

--- a/tests/test_consolidated_order_book.py
+++ b/tests/test_consolidated_order_book.py
@@ -1,0 +1,121 @@
+"""Pure unit tests for the consolidated order book wrapper.
+
+The folding rule itself lives in sdk-go and is tested there. What Python owns is
+the wrapper: forwarding the frame to the binding, and decoding the JSON without
+losing the native/inverse split or the crossed flag. Those are exercised here by
+monkeypatching the Go binding, so they need no node.
+"""
+
+import json
+
+import trufnetwork_sdk_py.client as client_mod
+from trufnetwork_sdk_py.client import TNClient
+
+# A YES ask at 60 that is entirely native, and a bid at 40 that is entirely
+# inverse: the NO sell at 60 folded into the YES frame. Two levels that are
+# indistinguishable by size alone, so a wrapper that dropped the split or
+# mixed up the sides would show here.
+BOOK_JSON = json.dumps(
+    {
+        "query_id": 419,
+        "outcome": True,
+        "bids": [{"price": 40, "total": 20, "native": 0, "inverse": 20}],
+        "asks": [{"price": 60, "total": 10, "native": 10, "inverse": 0}],
+        "is_crossed": False,
+    }
+)
+
+
+def _client_without_connect() -> TNClient:
+    # Bypass __init__ (which would open a network client); the wrapper only
+    # forwards self.client to the (monkeypatched) binding.
+    c = TNClient.__new__(TNClient)
+    c.client = object()
+    return c
+
+
+def test_get_consolidated_order_book_forwards_and_parses(monkeypatch):
+    captured = {}
+
+    def fake_get_book(client, query_id, outcome):
+        captured["query_id"] = query_id
+        captured["outcome"] = outcome
+        return BOOK_JSON
+
+    monkeypatch.setattr(client_mod.truf_sdk, "GetConsolidatedOrderBook", fake_get_book, raising=False)
+
+    book = _client_without_connect().get_consolidated_order_book(419, True)
+
+    assert captured == {"query_id": 419, "outcome": True}
+    assert book["query_id"] == 419
+    assert book["is_crossed"] is False
+    assert book["asks"] == [{"price": 60, "total": 10, "native": 10, "inverse": 0}]
+    assert book["bids"] == [{"price": 40, "total": 20, "native": 0, "inverse": 20}], (
+        "the inverse volume must survive decoding: it is the NO liquidity that "
+        "reading the YES book alone would miss"
+    )
+
+
+def test_get_consolidated_order_book_defaults_to_the_yes_frame(monkeypatch):
+    captured = {}
+
+    def fake_get_book(client, query_id, outcome):
+        captured["outcome"] = outcome
+        return BOOK_JSON
+
+    monkeypatch.setattr(client_mod.truf_sdk, "GetConsolidatedOrderBook", fake_get_book, raising=False)
+
+    _client_without_connect().get_consolidated_order_book(419)
+
+    assert captured["outcome"] is True
+
+
+def test_get_consolidated_order_book_passes_the_no_frame_through(monkeypatch):
+    captured = {}
+
+    def fake_get_book(client, query_id, outcome):
+        captured["outcome"] = outcome
+        return json.dumps(
+            {"query_id": 419, "outcome": False, "bids": [], "asks": [], "is_crossed": False}
+        )
+
+    monkeypatch.setattr(client_mod.truf_sdk, "GetConsolidatedOrderBook", fake_get_book, raising=False)
+
+    book = _client_without_connect().get_consolidated_order_book(419, False)
+
+    assert captured["outcome"] is False
+    assert book["outcome"] is False
+
+
+def test_get_consolidated_order_book_reports_a_crossed_book(monkeypatch):
+    # A YES bid at 61 against a NO bid at 45 reads as a bid at 61 over an ask at
+    # 55 and never matches, because 61 + 45 is not 100. It is a state to render,
+    # not bad data, so the flag has to reach the caller intact.
+    crossed = json.dumps(
+        {
+            "query_id": 419,
+            "outcome": True,
+            "bids": [{"price": 61, "total": 100, "native": 100, "inverse": 0}],
+            "asks": [{"price": 55, "total": 100, "native": 0, "inverse": 100}],
+            "is_crossed": True,
+        }
+    )
+    monkeypatch.setattr(
+        client_mod.truf_sdk, "GetConsolidatedOrderBook", lambda c, q, o: crossed, raising=False
+    )
+
+    assert _client_without_connect().get_consolidated_order_book(419)["is_crossed"] is True
+
+
+def test_get_consolidated_order_book_empty_returns_an_empty_book(monkeypatch):
+    monkeypatch.setattr(
+        client_mod.truf_sdk, "GetConsolidatedOrderBook", lambda c, q, o: "", raising=False
+    )
+
+    assert _client_without_connect().get_consolidated_order_book(419, False) == {
+        "query_id": 419,
+        "outcome": False,
+        "bids": [],
+        "asks": [],
+        "is_crossed": False,
+    }

--- a/tests/test_order_book.py
+++ b/tests/test_order_book.py
@@ -477,6 +477,7 @@ class TestQueryOperationsValidation:
         assert hasattr(client, "get_order_book")
         assert hasattr(client, "get_user_positions")
         assert hasattr(client, "get_market_depth")
+        assert hasattr(client, "get_consolidated_order_book")
         assert hasattr(client, "get_best_prices")
         assert hasattr(client, "get_user_collateral")
 
@@ -539,6 +540,8 @@ class TestTypeDefinitions:
             OrderBookEntry,
             UserPosition,
             DepthLevel,
+            ConsolidatedLevel,
+            ConsolidatedOrderBook,
             BestPrices,
             UserCollateral,
             DistributionSummary,
@@ -553,6 +556,8 @@ class TestTypeDefinitions:
         assert OrderBookEntry is not None
         assert UserPosition is not None
         assert DepthLevel is not None
+        assert ConsolidatedLevel is not None
+        assert ConsolidatedOrderBook is not None
         assert BestPrices is not None
         assert UserCollateral is not None
         assert DistributionSummary is not None

--- a/tests/test_order_book_live.py
+++ b/tests/test_order_book_live.py
@@ -164,10 +164,18 @@ def test_the_opposite_outcome_reaches_the_ladder(books):
 
 def test_the_no_frame_is_the_yes_frame_reflected(live_client, two_sided_market):
     """One call answers either tab: a YES bid at p is a NO ask at 100-p."""
+    # Re-read BOTH frames. Re-reading only YES would miss an order placed after
+    # the first read and cancelled before the third: YES comes back identical
+    # while no_book was taken from a state that no longer exists, and the
+    # comparison below then fails on drift rather than on a defect. Arguing that
+    # a settled YES frame implies a settled NO frame would also lean on exactly
+    # the mirror property this test exists to verify.
     for _ in range(STABLE_READ_ATTEMPTS):
         yes_book = live_client.get_consolidated_order_book(two_sided_market, True)
         no_book = live_client.get_consolidated_order_book(two_sided_market, False)
-        if yes_book == live_client.get_consolidated_order_book(two_sided_market, True):
+        yes_again = live_client.get_consolidated_order_book(two_sided_market, True)
+        no_again = live_client.get_consolidated_order_book(two_sided_market, False)
+        if yes_book == yes_again and no_book == no_again:
             break
     else:
         pytest.skip("the book kept moving between reads; nothing stable to compare")

--- a/tests/test_order_book_live.py
+++ b/tests/test_order_book_live.py
@@ -1,0 +1,182 @@
+"""Live-network checks that the consolidated read folds the real chain correctly.
+
+The rest of the consolidated suite feeds the wrapper hand-written JSON, which
+proves the decoding but cannot prove the SDK reads the CHAIN the right way
+round. If the fold ever put the opposite outcome's quotes on the wrong side --
+NO bids arriving as YES bids instead of YES asks -- every one of those tests
+would still pass while the ladder pointed traders at quotes that cannot fill.
+That is the gap this file covers.
+
+Gated, because it needs a network carrying markets with real orders. Run it
+with:
+
+    TN_LIVE_NODE_URL=https://gateway.mainnet.truf.network pytest tests/test_order_book_live.py
+
+All calls are view actions, so the signing key needs no funds and controls
+nothing; a throwaway is generated unless TN_LIVE_PRIVATE_KEY is set.
+
+These assert RELATIONSHIPS between reads of the same market, never numbers.
+Live books move minute to minute, so a pinned value would fail by tomorrow.
+"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("TN_LIVE_NODE_URL"),
+    reason="live node not configured; set TN_LIVE_NODE_URL to run",
+)
+
+# Discovery costs two depth reads per market until a two-sided one turns up.
+# Mainnet carried ~130 open markets when this was written and the first page
+# already held one; the cap is headroom, not a target.
+MAX_MARKETS_SCANNED = 400
+
+# Retries before giving up on a market that will not hold still long enough to
+# be read twice.
+STABLE_READ_ATTEMPTS = 4
+
+
+@pytest.fixture(scope="module")
+def live_client():
+    from eth_account import Account
+
+    from trufnetwork_sdk_py.client import TNClient
+
+    key = os.getenv("TN_LIVE_PRIVATE_KEY") or Account.create().key.hex()
+    return TNClient(os.environ["TN_LIVE_NODE_URL"], key)
+
+
+def _quoted(levels) -> bool:
+    return any(level["buy_volume"] or level["sell_volume"] for level in levels)
+
+
+@pytest.fixture(scope="module")
+def two_sided_market(live_client) -> int:
+    """A market carrying resting orders on BOTH outcomes.
+
+    A one-sided market cannot show a fold: with nothing resting on NO, every
+    consolidated level is native and a wrapper that dropped the inverse side
+    entirely would still pass. Skip rather than fail when the network has none
+    -- an empty book is a fact about the day, not a defect.
+    """
+    offset = 0
+    scanned = 0
+
+    while scanned < MAX_MARKETS_SCANNED:
+        page = live_client.list_markets(settled_filter=False, limit=100, offset=offset)
+        if not page:
+            break
+        for market in page:
+            scanned += 1
+            query_id = market["id"]
+            if _quoted(live_client.get_market_depth(query_id, True)) and _quoted(
+                live_client.get_market_depth(query_id, False)
+            ):
+                return query_id
+        if len(page) < 100:
+            break
+        offset += 100
+
+    pytest.skip("no open market on this network quotes both outcomes right now")
+
+
+@pytest.fixture(scope="module")
+def books(live_client, two_sided_market):
+    """The raw YES and NO ladders and the consolidated book, read while the
+    market holds still.
+
+    Live books move. Comparing a consolidated read against separate raw reads
+    is comparing two points in time, so a mismatch there can mean drift rather
+    than a defect. Read the raw sides on both sides of the consolidated call and
+    only assert when they agree.
+    """
+    for _ in range(STABLE_READ_ATTEMPTS):
+        before_yes = live_client.get_market_depth(two_sided_market, True)
+        before_no = live_client.get_market_depth(two_sided_market, False)
+        book = live_client.get_consolidated_order_book(two_sided_market, True)
+        after_yes = live_client.get_market_depth(two_sided_market, True)
+        after_no = live_client.get_market_depth(two_sided_market, False)
+        if before_yes == after_yes and before_no == after_no:
+            return before_yes, before_no, book
+
+    pytest.skip("the book kept moving between reads; nothing stable to compare")
+
+
+def test_consolidated_bids_trace_back_to_resting_orders(books):
+    """A consolidated bid is a YES buy at p, or a NO SELL at 100-p.
+
+    The NO side is the half that matters. A resting sell of NO at 93c is a
+    standing bid for YES at 7c: a trader hits it by SELLING YES, both parties
+    sell, and the chain burns the share pair.
+    """
+    yes, no, book = books
+    yes_buy = {level["price"]: level["buy_volume"] for level in yes}
+    no_sell = {level["price"]: level["sell_volume"] for level in no}
+
+    for level in book["bids"]:
+        assert level["native"] == yes_buy.get(level["price"], 0), (
+            f"native bid volume at {level['price']}c is not a YES buy on the chain"
+        )
+        assert level["inverse"] == no_sell.get(100 - level["price"], 0), (
+            f"inverse bid volume at {level['price']}c is not a NO sell at "
+            f"{100 - level['price']}c on the chain"
+        )
+        assert level["total"] == level["native"] + level["inverse"]
+
+
+def test_consolidated_asks_trace_back_to_resting_orders(books):
+    """A consolidated ask is a YES sell at p, or a NO BUY at 100-p.
+
+    Hitting one means both parties buy and the chain mints a share pair.
+    """
+    yes, no, book = books
+    yes_sell = {level["price"]: level["sell_volume"] for level in yes}
+    no_buy = {level["price"]: level["buy_volume"] for level in no}
+
+    for level in book["asks"]:
+        assert level["native"] == yes_sell.get(level["price"], 0), (
+            f"native ask volume at {level['price']}c is not a YES sell on the chain"
+        )
+        assert level["inverse"] == no_buy.get(100 - level["price"], 0), (
+            f"inverse ask volume at {level['price']}c is not a NO buy at "
+            f"{100 - level['price']}c on the chain"
+        )
+        assert level["total"] == level["native"] + level["inverse"]
+
+
+def test_the_opposite_outcome_reaches_the_ladder(books):
+    """The point of the whole method: NO liquidity shows up in the YES frame.
+
+    The market was picked because both outcomes carry orders, so whatever rests
+    on NO has to surface as inverse volume on one side or the other. A fold that
+    silently discarded the opposite book would pass every assertion above and
+    fail this one.
+    """
+    _, _, book = books
+
+    assert any(level["inverse"] for level in book["bids"] + book["asks"]), (
+        "both outcomes are quoted, so the opposite book must contribute at "
+        "least one inverse level"
+    )
+
+
+def test_the_no_frame_is_the_yes_frame_reflected(live_client, two_sided_market):
+    """One call answers either tab: a YES bid at p is a NO ask at 100-p."""
+    for _ in range(STABLE_READ_ATTEMPTS):
+        yes_book = live_client.get_consolidated_order_book(two_sided_market, True)
+        no_book = live_client.get_consolidated_order_book(two_sided_market, False)
+        if yes_book == live_client.get_consolidated_order_book(two_sided_market, True):
+            break
+    else:
+        pytest.skip("the book kept moving between reads; nothing stable to compare")
+
+    def reflect(levels):
+        return sorted((100 - level["price"], level["total"]) for level in levels)
+
+    def flat(levels):
+        return sorted((level["price"], level["total"]) for level in levels)
+
+    assert reflect(yes_book["bids"]) == flat(no_book["asks"])
+    assert reflect(yes_book["asks"]) == flat(no_book["bids"])


### PR DESCRIPTION
`get_consolidated_order_book(query_id, outcome=True)` returns one outcome's book
with the opposite outcome's quotes folded in, so a Python caller sees the
liquidity that is actually executable rather than one side of it.

resolves: https://github.com/truflation/website/issues/4388

## Why

A binary market's two books are two views of one position, and the matching
engine fills across them. A resting SELL NO at 93c is a standing bid for YES at
7c: a trader hits it by selling YES, both parties sell, and the chain burns the
share pair. `get_market_depth` on the YES outcome cannot show that quote, so the
market reads thinner than it is.

How much thinner is not a rounding error. On mainnet market 423 while this was
being written, the best YES ask was 16c with 3,443 shares behind it — 3,374 of
them resting in the NO book. The YES ladder alone showed 69.

sdk-js and sdk-go both carry this already. Python was the last SDK without it.

## What is in it

- `get_consolidated_order_book(query_id, outcome=True)` on `TNClient`, with
  `ConsolidatedOrderBook` and `ConsolidatedLevel`. `outcome` frames the prices;
  the NO-framed book is the YES-framed book reflected, so one call answers
  either tab.
- `GetConsolidatedOrderBook` in `bindings/bindings.go`, delegating to sdk-go and
  handing the book back as JSON. The folding rule stays in sdk-go, so Python, Go
  and TypeScript agree on what a market's executable ladder is instead of
  carrying three copies of a rule that has to stay identical.
- sdk-go moved to `v0.7.5-0.20260806143829-879be314b9a4`, the commit carrying
  both consolidation PRs. The consequence worth knowing: the book comes from a
  single `get_full_market_depth` read, so both sides are one snapshot of the
  chain and `is_crossed` describes a state the book was really in rather than an
  artifact of reading the two sides a moment apart.
- Each level keeps `native` and `inverse` separately, not just their sum. Mint
  and burn fire only when the two prices sum to exactly 100, while a direct
  same-outcome match crosses, so one order fills every native level past its
  limit plus exactly **one** inverse level. A caller quoting a fill needs the
  split to get that right.
- `DepthLevel` corrected to the shape `get_market_depth` actually returns —
  `price`, `buy_volume`, `sell_volume`, where it claimed `price`,
  `total_amount`. Type hints only, nothing in the tree read it, and the new live
  test reads those keys.

## Testing

`go build ./...` and `go vet ./bindings/` clean, bindings rebuilt with
`make gopy_build`.

- 102 offline tests pass.
- `tests/test_order_book.py` passes against a local node (44 tests).
- `TN_LIVE_NODE_URL=https://gateway.mainnet.truf.network pytest tests/test_order_book_live.py`
  — 4 passed against mainnet.

The unit tests monkeypatch the binding, so they pin the wrapper's contract —
argument forwarding, decoding, the crossed flag, the empty book — and nothing
more. What they cannot show is that the SDK reads the chain the right way round:
a fold that put NO bids on the bid side instead of the ask side would satisfy
every one of them while pointing traders at quotes that cannot fill.

That is what `tests/test_order_book_live.py` covers. It finds a market quoting
both outcomes, then checks each consolidated level against the raw ladders: a
bid's native volume must be a YES buy at that price and its inverse volume a NO
**sell** at 100 minus it, asks the mirror, and the NO-framed book must be the
YES-framed book reflected. It asserts relationships between two reads, never
numbers, because live books move. Gated on `TN_LIVE_NODE_URL` in the style of
`test_forecast_live.py`, so CI skips it.

## What is not in it

`get_market_depth` is untouched and stays the right call when you want one
outcome — a depth chart, or a bot quoting a single side.

No Python copy of the folding rule. `forecast.py` has its own consolidation for
the bucket-forecast path, but that one works on `BucketDepth` assembled from raw
order reads rather than on aggregated depth, so it is a separate piece of code
with its own tests and is untouched here.

The types are importable from `trufnetwork_sdk_py.client`, not re-exported from
the package root, matching `DepthLevel`, `BestPrices` and the rest of the
order-book types.

## On the sdk-go pin

sdk-go has no tag carrying the consolidation work yet, so this pins the commit.
That is the normal shape of a bump here — seven of the last eight sdk-go bumps
in this repo pinned a pseudo-version, and a tag replaced it later.

Mainnet already serves `get_full_market_depth`, which is why the live test above
runs green against it. A network still on an older node will not.

## Follow-ups

`get_market_forecast` still reads each bucket's YES and NO books separately and
carries the same cross-height exposure this removes. It consumes individual
orders rather than aggregated depth, so moving it is its own change with its own
review, in sdk-go first. Nothing tracks it yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consolidated order book retrieval for binary markets.
  * View executable bids and asks with native and inverse liquidity, query metadata, and crossed-book status.
  * Supports selecting either outcome frame, with an initialized empty response when no data is available.
  * Updated depth levels to distinguish buy and sell volumes.

* **Documentation**
  * Added API reference documentation and usage examples for consolidated order books.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->