### PR TITLE
feat: read a whole market's depth in one call from Python

### DIFF
--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -2431,6 +2431,49 @@ func GetMarketDepth(client *tnclient.Client, queryID int, outcome bool) (string,
 	return string(jsonBytes), nil
 }
 
+// GetFullMarketDepth returns aggregated volume per price level for BOTH
+// outcomes, from one read.
+//
+// Same aggregation as GetMarketDepth, for the whole market instead of one
+// outcome, with each level tagged by the outcome it rests on. Rows arrive YES
+// first then NO, price ascending within each.
+//
+// One statement is one snapshot. Anything that compares the two outcomes to
+// each other wants this rather than two GetMarketDepth calls, because between
+// two calls an order can land on one side and not the other.
+func GetFullMarketDepth(client *tnclient.Client, queryID int) (string, error) {
+	ctx := context.Background()
+
+	orderBook, err := client.LoadOrderBook()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to load order book")
+	}
+
+	results, err := orderBook.GetFullMarketDepth(ctx, types.GetFullMarketDepthInput{
+		QueryID: queryID,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get full market depth")
+	}
+
+	levels := make([]map[string]any, len(results))
+	for i, level := range results {
+		levels[i] = map[string]any{
+			"outcome":     level.Outcome,
+			"price":       level.Price,
+			"buy_volume":  level.BuyVolume,
+			"sell_volume": level.SellVolume,
+		}
+	}
+
+	jsonBytes, err := json.Marshal(levels)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal full market depth")
+	}
+
+	return string(jsonBytes), nil
+}
+
 // GetBestPrices returns current bid/ask spread
 func GetBestPrices(client *tnclient.Client, queryID int, outcome bool) (string, error) {
 	ctx := context.Background()

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1444,6 +1444,37 @@ Get aggregated order book depth for a market outcome.
 
 **Returns:** List of depth levels with aggregated amounts at each price.
 
+#### `client.get_full_market_depth(query_id) -> list[FullDepthLevel]`
+
+Get aggregated volume per price level for **both** outcomes, from one read.
+
+**Parameters:**
+- `query_id: int` - Market ID
+
+Same aggregation as `get_market_depth`, for the whole market instead of one
+outcome, with each level tagged by the outcome it rests on. Rows arrive YES
+first then NO, price ascending within each.
+
+One statement is one snapshot. Anything comparing the two outcomes to each other
+wants this rather than two `get_market_depth` calls, because between two calls an
+order can land on one side and not the other, and the pair then describes a
+market state that never existed.
+
+**Returns:** List of `FullDepthLevel` — `outcome` (True=YES), `price`,
+`buy_volume`, `sell_volume`.
+
+**Example:**
+```python
+for level in client.get_full_market_depth(query_id=419):
+    side = "YES" if level["outcome"] else "NO"
+    print(f"{side} {level['price']}c: {level['buy_volume']} buy, "
+          f"{level['sell_volume']} sell")
+```
+
+`get_market_depth` is unchanged and stays the right call when you want one
+outcome: a depth chart, or a bot quoting a single side. Requires a node carrying
+`get_full_market_depth`.
+
 #### `client.get_consolidated_order_book(query_id, outcome=True) -> ConsolidatedOrderBook`
 
 Get one outcome's book with the opposite outcome's quotes folded in.

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -258,6 +258,19 @@ class DepthLevel(TypedDict):
     sell_volume: int
 
 
+class FullDepthLevel(TypedDict):
+    """Market depth at one outcome's price level, as get_full_market_depth
+    returns it.
+
+    The ``outcome`` tag is what a ``DepthLevel`` leaves implicit, because the
+    call it comes from asked for one outcome. True=YES, False=NO.
+    """
+    outcome: bool
+    price: int
+    buy_volume: int
+    sell_volume: int
+
+
 class ConsolidatedLevel(TypedDict):
     """One price level of a consolidated order book, in the requested frame.
 
@@ -2830,6 +2843,33 @@ class TNClient:
             return []
 
         return cast(list[DepthLevel], json.loads(json_str))
+
+    def get_full_market_depth(self, query_id: int) -> list[FullDepthLevel]:
+        """Get aggregated volume per price level for BOTH outcomes, in one read.
+
+        Same aggregation as ``get_market_depth``, for the whole market instead
+        of one outcome, with each level tagged by the outcome it rests on. Rows
+        arrive YES first then NO, price ascending within each.
+
+        One statement is one snapshot. Anything that compares the two outcomes
+        to each other wants this rather than two ``get_market_depth`` calls,
+        because between two calls an order can land on one side and not the
+        other, and the pair then describes a market state that never existed.
+
+        ``get_market_depth`` is unchanged and stays the right call when you want
+        one outcome: a depth chart, or a bot quoting a single side.
+
+        Args:
+            query_id: The market to read.
+
+        Requires a node carrying ``get_full_market_depth``.
+        """
+        json_str = truf_sdk.GetFullMarketDepth(self.client, query_id)
+
+        if not json_str:
+            return []
+
+        return cast(list[FullDepthLevel], json.loads(json_str))
 
     def get_consolidated_order_book(
         self, query_id: int, outcome: bool = True

--- a/tests/test_full_market_depth.py
+++ b/tests/test_full_market_depth.py
@@ -1,0 +1,66 @@
+"""Pure unit tests for the whole-market depth read.
+
+The aggregation runs on the node and the row parsing in sdk-go, both tested
+there. What Python owns is the wrapper: forwarding the market id, and decoding
+rows without losing the outcome tag. Those are exercised here by monkeypatching
+the Go binding, so they need no node.
+"""
+
+import json
+
+import trufnetwork_sdk_py.client as client_mod
+from trufnetwork_sdk_py.client import TNClient
+
+# A YES sell at 60 and a NO sell at 60. In their own books they are the same
+# number; only the tag says one is an ask at 60 and the other a bid at 40 once
+# framed in YES. Lose the tag and the two are indistinguishable.
+DEPTH_JSON = json.dumps(
+    [
+        {"outcome": True, "price": 60, "buy_volume": 0, "sell_volume": 10},
+        {"outcome": False, "price": 60, "buy_volume": 0, "sell_volume": 20},
+    ]
+)
+
+
+def _client_without_connect() -> TNClient:
+    # Bypass __init__ (which would open a network client); the wrapper only
+    # forwards self.client to the (monkeypatched) binding.
+    c = TNClient.__new__(TNClient)
+    c.client = object()
+    return c
+
+
+def test_get_full_market_depth_forwards_and_parses(monkeypatch):
+    captured = {}
+
+    def fake_get_depth(client, query_id):
+        captured["query_id"] = query_id
+        return DEPTH_JSON
+
+    monkeypatch.setattr(client_mod.truf_sdk, "GetFullMarketDepth", fake_get_depth, raising=False)
+
+    depth = _client_without_connect().get_full_market_depth(419)
+
+    assert captured == {"query_id": 419}
+    assert len(depth) == 2
+    assert depth[0] == {"outcome": True, "price": 60, "buy_volume": 0, "sell_volume": 10}
+    assert depth[1] == {"outcome": False, "price": 60, "buy_volume": 0, "sell_volume": 20}
+
+
+def test_get_full_market_depth_keeps_the_outcome_tag(monkeypatch):
+    monkeypatch.setattr(
+        client_mod.truf_sdk, "GetFullMarketDepth", lambda c, q: DEPTH_JSON, raising=False
+    )
+
+    depth = _client_without_connect().get_full_market_depth(419)
+
+    assert [level["outcome"] for level in depth] == [True, False], (
+        "the tag is the only thing separating a YES level from the NO level at "
+        "the same price"
+    )
+
+
+def test_get_full_market_depth_empty_returns_list(monkeypatch):
+    monkeypatch.setattr(client_mod.truf_sdk, "GetFullMarketDepth", lambda c, q: "", raising=False)
+
+    assert _client_without_connect().get_full_market_depth(419) == []

--- a/tests/test_order_book.py
+++ b/tests/test_order_book.py
@@ -477,6 +477,7 @@ class TestQueryOperationsValidation:
         assert hasattr(client, "get_order_book")
         assert hasattr(client, "get_user_positions")
         assert hasattr(client, "get_market_depth")
+        assert hasattr(client, "get_full_market_depth")
         assert hasattr(client, "get_consolidated_order_book")
         assert hasattr(client, "get_best_prices")
         assert hasattr(client, "get_user_collateral")
@@ -540,6 +541,7 @@ class TestTypeDefinitions:
             OrderBookEntry,
             UserPosition,
             DepthLevel,
+            FullDepthLevel,
             ConsolidatedLevel,
             ConsolidatedOrderBook,
             BestPrices,
@@ -556,6 +558,7 @@ class TestTypeDefinitions:
         assert OrderBookEntry is not None
         assert UserPosition is not None
         assert DepthLevel is not None
+        assert FullDepthLevel is not None
         assert ConsolidatedLevel is not None
         assert ConsolidatedOrderBook is not None
         assert BestPrices is not None

--- a/tests/test_order_book_live.py
+++ b/tests/test_order_book_live.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.skipif(
     reason="live node not configured; set TN_LIVE_NODE_URL to run",
 )
 
-# Discovery costs two depth reads per market until a two-sided one turns up.
+# Discovery costs one depth read per market until a two-sided one turns up.
 # Mainnet carried ~130 open markets when this was written and the first page
 # already held one; the cap is headroom, not a target.
 MAX_MARKETS_SCANNED = 400
@@ -60,6 +60,9 @@ def two_sided_market(live_client) -> int:
     consolidated level is native and a wrapper that dropped the inverse side
     entirely would still pass. Skip rather than fail when the network has none
     -- an empty book is a fact about the day, not a defect.
+
+    "Is this market two-sided?" is the question get_full_market_depth exists to
+    answer, so the scan asks it once per market rather than once per outcome.
     """
     offset = 0
     scanned = 0
@@ -70,16 +73,42 @@ def two_sided_market(live_client) -> int:
             break
         for market in page:
             scanned += 1
-            query_id = market["id"]
-            if _quoted(live_client.get_market_depth(query_id, True)) and _quoted(
-                live_client.get_market_depth(query_id, False)
-            ):
-                return query_id
+            depth = live_client.get_full_market_depth(market["id"])
+            yes = [level for level in depth if level["outcome"]]
+            no = [level for level in depth if not level["outcome"]]
+            if _quoted(yes) and _quoted(no):
+                return market["id"]
         if len(page) < 100:
             break
         offset += 100
 
     pytest.skip("no open market on this network quotes both outcomes right now")
+
+
+def test_full_market_depth_matches_two_single_outcome_reads(live_client, two_sided_market):
+    """The whole-market read and the per-outcome reads describe the same book.
+
+    This is what makes the new action safe to switch to: it aggregates the same
+    rows, it just does both outcomes in one statement. If the two ever disagreed
+    on anything but timing, every consolidated ladder built on it would be wrong
+    while the per-outcome reads stayed right.
+    """
+    for _ in range(STABLE_READ_ATTEMPTS):
+        before = live_client.get_full_market_depth(two_sided_market)
+        yes = live_client.get_market_depth(two_sided_market, True)
+        no = live_client.get_market_depth(two_sided_market, False)
+        if before == live_client.get_full_market_depth(two_sided_market):
+            break
+    else:
+        pytest.skip("the book kept moving between reads; nothing stable to compare")
+
+    def rows(levels):
+        return sorted(
+            (level["price"], level["buy_volume"], level["sell_volume"]) for level in levels
+        )
+
+    assert rows(level for level in before if level["outcome"]) == rows(yes)
+    assert rows(level for level in before if not level["outcome"]) == rows(no)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
`get_full_market_depth(query_id)` returns aggregated volume per price level for
**both** outcomes from one read, each level tagged with the outcome it rests on.

Related, no closing keyword:

- resolves: https://github.com/truflation/website/issues/4445
- <https://github.com/truflation/website/issues/4387>

#4445 is the Problem this action was written for and is already closed, by the
sdk-go and sdk-js PRs that consumed it. Python's consolidated book was reading
through it from the moment the preceding PR landed the sdk-go pin, so the job
story is satisfied without this. What is left is the direct accessor, which is
API parity rather than the problem.

## Why

`get_market_depth` answers for one outcome, so comparing the two sides of a
market takes two calls at two independent points in time. An order landing
between them appears on one side and not the other, and the pair then describes
a market state that never existed. One statement is one snapshot, and that whole
class of artifact goes away.

The node has carried `get_full_market_depth` since trufnetwork/node#1413 and it
is live on mainnet. sdk-js and sdk-go both expose it. Python was the last SDK
reading a market two calls at a time.

## What is in it

- `get_full_market_depth(query_id)` on `TNClient`, returning `FullDepthLevel`
  rows — `outcome`, `price`, `buy_volume`, `sell_volume`. Same aggregation as
  `get_market_depth`, for the whole market instead of one outcome. Rows arrive
  YES first then NO, price ascending within each.
- `GetFullMarketDepth` in `bindings/bindings.go`, delegating to sdk-go.
- Unit tests pinning the wrapper: forwarding, decoding, and that the outcome tag
  survives. The tag is the only thing separating a YES level from the NO level at
  the same price, so the fixture puts a sell at 60 on each side — lose the tag
  and the two rows are indistinguishable.
- A live check that the whole-market read and two per-outcome reads describe the
  same book, plus the live discovery scan switched over to it: "is this market
  two-sided?" is exactly the question this action exists to answer, so it now
  costs one read per market rather than two.

## Testing

`go build ./...` and `go vet ./bindings/` clean, bindings rebuilt with
`make gopy_build`.

- 105 offline tests pass.
- `tests/test_order_book.py` passes against a local node (44 tests).
- `TN_LIVE_NODE_URL=https://gateway.mainnet.truf.network pytest tests/test_order_book_live.py`
  — 5 passed against mainnet, including the new equivalence check.

The equivalence check is the one that matters. If the two reads ever disagreed on
anything but timing, every consolidated ladder built on the new one would be
wrong while the per-outcome reads stayed right, and nothing offline would notice.
It re-reads to confirm the market held still before asserting, so a moving book
skips rather than fails.

## What is not in it

`get_market_depth` is untouched and stays the right call when you want one
outcome — a depth chart, or a bot quoting a single side.

`get_consolidated_order_book` needs no change: it already reads through this
action inside sdk-go, from the pin #132 brought in. This adds the direct
accessor for callers who want the raw both-outcome depth, which is what sdk-js
and sdk-go each expose alongside their consolidated method.

## Note on the base branch

Was stacked on #132 while that was open. #132 has since merged, so this now
targets `main` and carries a single commit.

- <https://github.com/trufnetwork/sdk-py/pull/132>