### PR TITLE
feat: quote a fill against a consolidated order book from Python

### DIFF
--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -2589,6 +2589,155 @@ func consolidatedLevels(levels []forecast.ConsolidatedLevel) []map[string]any {
 	return out
 }
 
+// Quoting a fill against a consolidated ladder.
+//
+// The model lives in sdk-go, so Python, Go and TypeScript agree on what an order
+// will actually do. A consolidated ladder is not sweepable: match_direct crosses
+// through the order's limit, but match_mint and match_burn only fire when the two
+// prices sum to exactly 100, so an order at limit P fills every native level past
+// P plus exactly ONE inverse level. Summing the ladder overstates what one order
+// can take, and fillable size does not even grow monotonically with the limit.
+//
+// A limit of 0 or less means "choose the best limit", which is what a trader
+// placing a market order wants. Pass a positive limit to quote a price the caller
+// has already settled on, such as one a self-trade guard moved.
+
+// quoteLevels reads one side of a consolidated ladder back out of JSON.
+func quoteLevels(raw []map[string]any) []forecast.ConsolidatedLevel {
+	levels := make([]forecast.ConsolidatedLevel, 0, len(raw))
+	for _, entry := range raw {
+		number := func(key string) float64 {
+			value, _ := entry[key].(float64)
+			return value
+		}
+		levels = append(levels, forecast.ConsolidatedLevel{
+			Price:   number("price"),
+			Total:   number("total"),
+			Native:  number("native"),
+			Inverse: number("inverse"),
+		})
+	}
+	return levels
+}
+
+// consolidatedBookSides pulls the bids and asks out of a consolidated book's JSON.
+func consolidatedBookSides(bookJSON string) (bids, asks []forecast.ConsolidatedLevel, err error) {
+	var book struct {
+		Bids []map[string]any `json:"bids"`
+		Asks []map[string]any `json:"asks"`
+	}
+	if err := json.Unmarshal([]byte(bookJSON), &book); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to parse consolidated order book")
+	}
+	return quoteLevels(book.Bids), quoteLevels(book.Asks), nil
+}
+
+// quoteFills renders a quote's legs for JSON.
+func quoteFills(fills []forecast.ConsolidatedFill) []map[string]any {
+	out := make([]map[string]any, len(fills))
+	for i, fill := range fills {
+		out[i] = map[string]any{
+			"price":  fill.Price,
+			"shares": fill.Shares,
+			"path":   string(fill.Path),
+		}
+	}
+	return out
+}
+
+// optionalPrice renders a price that may be absent.
+//
+// The Go model reports 0 for a price it could not choose, which no tradable price
+// can be. Python reads that as None rather than a free fill.
+func optionalPrice(price float64) any {
+	if price <= 0 {
+		return nil
+	}
+	return price
+}
+
+// marshalBuyQuote renders a buy quote for JSON.
+func marshalBuyQuote(quote forecast.ConsolidatedBuyQuote) (string, error) {
+	jsonBytes, err := json.Marshal(map[string]any{
+		"limit_price":          optionalPrice(quote.LimitPrice),
+		"filled_shares":        quote.FilledShares,
+		"available_shares":     quote.AvailableShares,
+		"estimated_total_cost": quote.EstimatedTotalCost,
+		"average_price":        optionalPrice(quote.AveragePrice),
+		"is_fully_filled":      quote.IsFullyFilled,
+		"fills":                quoteFills(quote.Fills),
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal buy quote")
+	}
+	return string(jsonBytes), nil
+}
+
+// marshalSellQuote renders a sell quote for JSON.
+func marshalSellQuote(quote forecast.ConsolidatedSellQuote) (string, error) {
+	jsonBytes, err := json.Marshal(map[string]any{
+		"limit_price":        optionalPrice(quote.LimitPrice),
+		"filled_shares":      quote.FilledShares,
+		"available_shares":   quote.AvailableShares,
+		"estimated_proceeds": quote.EstimatedProceeds,
+		"average_price":      optionalPrice(quote.AveragePrice),
+		"is_fully_filled":    quote.IsFullyFilled,
+		"fills":              quoteFills(quote.Fills),
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal sell quote")
+	}
+	return string(jsonBytes), nil
+}
+
+// QuoteConsolidatedBuyFromBook quotes a buy against a book the caller already
+// holds, without reading the chain again.
+func QuoteConsolidatedBuyFromBook(bookJSON string, shares, limit float64) (string, error) {
+	_, asks, err := consolidatedBookSides(bookJSON)
+	if err != nil {
+		return "", err
+	}
+
+	if limit > 0 {
+		return marshalBuyQuote(forecast.QuoteConsolidatedBuyAtPrice(asks, shares, limit))
+	}
+	return marshalBuyQuote(forecast.QuoteConsolidatedBuy(asks, shares))
+}
+
+// QuoteConsolidatedSellFromBook quotes a sell against a book the caller already
+// holds, without reading the chain again.
+func QuoteConsolidatedSellFromBook(bookJSON string, shares, limit float64) (string, error) {
+	bids, _, err := consolidatedBookSides(bookJSON)
+	if err != nil {
+		return "", err
+	}
+
+	if limit > 0 {
+		return marshalSellQuote(forecast.QuoteConsolidatedSellAtPrice(bids, shares, limit))
+	}
+	return marshalSellQuote(forecast.QuoteConsolidatedSell(bids, shares))
+}
+
+// QuoteConsolidatedBuy reads a market's consolidated book and quotes a buy
+// against it.
+func QuoteConsolidatedBuy(client *tnclient.Client, queryID int, outcome bool, shares, limit float64) (string, error) {
+	bookJSON, err := GetConsolidatedOrderBook(client, queryID, outcome)
+	if err != nil {
+		return "", err
+	}
+	return QuoteConsolidatedBuyFromBook(bookJSON, shares, limit)
+}
+
+// QuoteConsolidatedSell reads a market's consolidated book and quotes a sell
+// against it.
+func QuoteConsolidatedSell(client *tnclient.Client, queryID int, outcome bool, shares, limit float64) (string, error) {
+	bookJSON, err := GetConsolidatedOrderBook(client, queryID, outcome)
+	if err != nil {
+		return "", err
+	}
+	return QuoteConsolidatedSellFromBook(bookJSON, shares, limit)
+}
+
 // GetUserCollateral returns caller's total locked collateral value
 func GetUserCollateral(client *tnclient.Client) (string, error) {
 	ctx := context.Background()

--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"reflect"
 	"strconv"
@@ -2598,9 +2599,14 @@ func consolidatedLevels(levels []forecast.ConsolidatedLevel) []map[string]any {
 // P plus exactly ONE inverse level. Summing the ladder overstates what one order
 // can take, and fillable size does not even grow monotonically with the limit.
 //
-// A limit of 0 or less means "choose the best limit", which is what a trader
-// placing a market order wants. Pass a positive limit to quote a price the caller
-// has already settled on, such as one a self-trade guard moved.
+// A NaN limit means "choose the best limit", which is what a trader placing a
+// market order wants. Pass a real limit to quote a price the caller has already
+// settled on, such as one a self-trade guard moved.
+//
+// NaN rather than 0 or a negative number, because every real value has to reach
+// forecast.Submittable: an order can only carry a whole cent from 1 through 99,
+// and a caller who asks for 0 or 100 should be told nothing fills rather than
+// silently handed a price the model picked for them.
 
 // quoteLevels reads one side of a consolidated ladder back out of JSON.
 func quoteLevels(raw []map[string]any) []forecast.ConsolidatedLevel {
@@ -2698,10 +2704,10 @@ func QuoteConsolidatedBuyFromBook(bookJSON string, shares, limit float64) (strin
 		return "", err
 	}
 
-	if limit > 0 {
-		return marshalBuyQuote(forecast.QuoteConsolidatedBuyAtPrice(asks, shares, limit))
+	if math.IsNaN(limit) {
+		return marshalBuyQuote(forecast.QuoteConsolidatedBuy(asks, shares))
 	}
-	return marshalBuyQuote(forecast.QuoteConsolidatedBuy(asks, shares))
+	return marshalBuyQuote(forecast.QuoteConsolidatedBuyAtPrice(asks, shares, limit))
 }
 
 // QuoteConsolidatedSellFromBook quotes a sell against a book the caller already
@@ -2712,10 +2718,10 @@ func QuoteConsolidatedSellFromBook(bookJSON string, shares, limit float64) (stri
 		return "", err
 	}
 
-	if limit > 0 {
-		return marshalSellQuote(forecast.QuoteConsolidatedSellAtPrice(bids, shares, limit))
+	if math.IsNaN(limit) {
+		return marshalSellQuote(forecast.QuoteConsolidatedSell(bids, shares))
 	}
-	return marshalSellQuote(forecast.QuoteConsolidatedSell(bids, shares))
+	return marshalSellQuote(forecast.QuoteConsolidatedSellAtPrice(bids, shares, limit))
 }
 
 // QuoteConsolidatedBuy reads a market's consolidated book and quotes a buy

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1541,6 +1541,56 @@ chain and `is_crossed` describes a state the book was really in. Requires a node
 carrying that action. The folding itself runs in sdk-go, so Python, Go and
 TypeScript agree on what a market's executable ladder is.
 
+#### Quoting a fill
+
+Answers what an order of a given size will actually do against a consolidated
+ladder, so no caller has to re-derive the matching rules. The model runs in
+sdk-go, like the folding above.
+
+```python
+from trufnetwork_sdk_py.client import quote_consolidated_buy_from_book
+
+book = client.get_consolidated_order_book(query_id=419)
+quote = quote_consolidated_buy_from_book(book, 700)
+
+print(f"submit {quote['limit_price']:.0f}c for {quote['filled_shares']:.0f} shares, "
+      f"${quote['estimated_total_cost']:.2f}")
+for fill in quote["fills"]:
+    print(f"  {fill['shares']:.0f} @ {fill['price']:.0f}c by {fill['path']}")
+```
+
+`quote_consolidated_buy_from_book` reads the book's `asks` and
+`quote_consolidated_sell_from_book` reads its `bids`, so one read answers both
+directions. `client.quote_consolidated_buy(query_id, shares)` and
+`client.quote_consolidated_sell(query_id, shares)` fetch the book themselves,
+which costs one chain read per quote — hold the book yourself when quoting
+repeatedly, such as a bot re-pricing on every tick.
+
+Three things the returned quote makes explicit, each of which a hand-rolled
+ladder walk gets wrong:
+
+- **`available_shares` is not the ladder's total.** It is the most any single
+  order can take, which is smaller whenever inverse volume rests at more than one
+  price. A ladder summing to 350 can cap one order at 200.
+- **Fillable size is not monotonic in the limit price.** Raising the limit can
+  lose the inverse level the fill was counting on, so the model evaluates every
+  candidate price instead of walking down the ladder.
+- **A sell pays its limit on every share.** A direct match pays the seller the
+  ask price and refunds the buyer the difference, so crediting each resting bid
+  its own price overstates any sell reaching past one level.
+
+`fills` carries each leg's `path` — `"direct"`, `"mint"` or `"burn"` — for
+callers that want to show how the order settles.
+
+**Choosing the limit is the caller's policy, not the SDK's.** Left to itself the
+model applies one reasonable default: the limit that fills the most, cheapest for
+a buy and highest for a sell. Pass `limit_price` to quote a price you have
+already settled on, such as a ceiling or one a self-trade guard moved.
+
+The quote assumes the order reaches the front of the queue at its price. Matching
+is FIFO within a level, so an older order resting at the same price takes the
+counterparty first and the real fill comes up short.
+
 ### Market Forecasting
 
 Prediction markets price **ranges**, not values. A five-bucket EPS market says

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1553,11 +1553,17 @@ from trufnetwork_sdk_py.client import quote_consolidated_buy_from_book
 book = client.get_consolidated_order_book(query_id=419)
 quote = quote_consolidated_buy_from_book(book, 700)
 
-print(f"submit {quote['limit_price']:.0f}c for {quote['filled_shares']:.0f} shares, "
-      f"${quote['estimated_total_cost']:.2f}")
-for fill in quote["fills"]:
-    print(f"  {fill['shares']:.0f} @ {fill['price']:.0f}c by {fill['path']}")
+if quote["limit_price"] is None:
+    print("nothing fillable")
+else:
+    print(f"submit {quote['limit_price']:.0f}c for {quote['filled_shares']:.0f} shares, "
+          f"${quote['estimated_total_cost']:.2f}")
+    for fill in quote["fills"]:
+        print(f"  {fill['shares']:.0f} @ {fill['price']:.0f}c by {fill['path']}")
 ```
+
+`limit_price` is `None` whenever no order can be quoted — an empty book, or a
+`limit_price` the chain would reject — so branch on it before formatting.
 
 `quote_consolidated_buy_from_book` reads the book's `asks` and
 `quote_consolidated_sell_from_book` reads its `bids`, so one read answers both
@@ -1586,6 +1592,12 @@ callers that want to show how the order settles.
 model applies one reasonable default: the limit that fills the most, cheapest for
 a buy and highest for a sell. Pass `limit_price` to quote a price you have
 already settled on, such as a ceiling or one a self-trade guard moved.
+
+A limit only counts if an order could carry it: a whole cent from 1 through 99,
+which is what the node accepts. The model never chooses a limit outside that, and
+a `limit_price` outside it quotes nothing — `available_shares` is still filled in,
+so a zero fill beside a non-zero `available_shares` says the limit was the
+problem rather than the book.
 
 The quote assumes the order reaches the front of the queue at its price. Matching
 is FIFO within a level, so an older order resting at the same price takes the

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558
-	github.com/trufnetwork/sdk-go v0.7.5-0.20260814134004-d16eb9efd975
+	github.com/trufnetwork/sdk-go v0.7.5-0.20260814140741-d244d09e7b7f
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558
-	github.com/trufnetwork/sdk-go v0.7.5-0.20260814140741-d244d09e7b7f
+	github.com/trufnetwork/sdk-go v0.7.5
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558
-	github.com/trufnetwork/sdk-go v0.7.5-0.20260806143829-879be314b9a4
+	github.com/trufnetwork/sdk-go v0.7.5-0.20260814134004-d16eb9efd975
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.sum
+++ b/go.sum
@@ -60,12 +60,8 @@ github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558 h1:I49YGUiU
 github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558 h1:m7a9HITFMXJF22QznIKoAdeiH8eZxWPU8IRzgcyNMo8=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
-github.com/trufnetwork/sdk-go v0.7.5-0.20260806143829-879be314b9a4 h1:Ew5cITYYgOw2GhDhTVZz5zjVQFxStTiw3JDaWA97l0I=
-github.com/trufnetwork/sdk-go v0.7.5-0.20260806143829-879be314b9a4/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
-github.com/trufnetwork/sdk-go v0.7.5-0.20260814134004-d16eb9efd975 h1:HUsVUVOyM8SyhD4E0XlShsP3GLYhDhClU7SKjjUhrGA=
-github.com/trufnetwork/sdk-go v0.7.5-0.20260814134004-d16eb9efd975/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
-github.com/trufnetwork/sdk-go v0.7.5-0.20260814140741-d244d09e7b7f h1:nlZTRAOfikeFFEp3QEG/CAEF84JyrQrpW0TkU/mmH/E=
-github.com/trufnetwork/sdk-go v0.7.5-0.20260814140741-d244d09e7b7f/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
+github.com/trufnetwork/sdk-go v0.7.5 h1:gSUwhuLjbKBL/O9ZR6NUZaSfQXuW4uA5sc3hVCpRBT8=
+github.com/trufnetwork/sdk-go v0.7.5/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/trufnetwork/sdk-go v0.7.5-0.20260806143829-879be314b9a4 h1:Ew5cITYYgO
 github.com/trufnetwork/sdk-go v0.7.5-0.20260806143829-879be314b9a4/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
 github.com/trufnetwork/sdk-go v0.7.5-0.20260814134004-d16eb9efd975 h1:HUsVUVOyM8SyhD4E0XlShsP3GLYhDhClU7SKjjUhrGA=
 github.com/trufnetwork/sdk-go v0.7.5-0.20260814134004-d16eb9efd975/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
+github.com/trufnetwork/sdk-go v0.7.5-0.20260814140741-d244d09e7b7f h1:nlZTRAOfikeFFEp3QEG/CAEF84JyrQrpW0TkU/mmH/E=
+github.com/trufnetwork/sdk-go v0.7.5-0.20260814140741-d244d09e7b7f/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558 h1:m7a9
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/sdk-go v0.7.5-0.20260806143829-879be314b9a4 h1:Ew5cITYYgOw2GhDhTVZz5zjVQFxStTiw3JDaWA97l0I=
 github.com/trufnetwork/sdk-go v0.7.5-0.20260806143829-879be314b9a4/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
+github.com/trufnetwork/sdk-go v0.7.5-0.20260814134004-d16eb9efd975 h1:HUsVUVOyM8SyhD4E0XlShsP3GLYhDhClU7SKjjUhrGA=
+github.com/trufnetwork/sdk-go v0.7.5-0.20260814134004-d16eb9efd975/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -300,6 +300,56 @@ class ConsolidatedOrderBook(TypedDict):
     is_crossed: bool
 
 
+ConsolidatedFillPath = Literal["direct", "mint", "burn"]
+
+
+class ConsolidatedFill(TypedDict):
+    """One leg of a quoted fill, and how it reaches the chain.
+
+    ``direct`` matches an order resting in the same outcome's book. ``mint``
+    pairs two buys and ``burn`` pairs two sells, and both need the two prices
+    to sum to exactly 100.
+    """
+    price: float
+    shares: float
+    path: ConsolidatedFillPath
+
+
+class ConsolidatedBuyQuote(TypedDict):
+    """What a buy of a given size can expect.
+
+    ``available_shares`` is the most one order can fill at any price, which is
+    less than the ladder's total whenever inverse volume rests at more than one
+    price. ``estimated_total_cost`` is in dollars: native legs pay their own
+    price and the inverse leg pays the limit. ``limit_price`` and
+    ``average_price`` are None when nothing fills.
+    """
+    limit_price: float | None
+    filled_shares: float
+    available_shares: float
+    estimated_total_cost: float
+    average_price: float | None
+    is_fully_filled: bool
+    fills: list[ConsolidatedFill]
+
+
+class ConsolidatedSellQuote(TypedDict):
+    """What a sell of a given size can expect.
+
+    ``estimated_proceeds`` is in dollars and every share pays the submitted
+    limit, so ``average_price`` is always that limit. A direct match pays the
+    seller the ask price and refunds the buyer the difference, which is why
+    crediting each resting bid its own price overstates a multi-level sell.
+    """
+    limit_price: float | None
+    filled_shares: float
+    available_shares: float
+    estimated_proceeds: float
+    average_price: float | None
+    is_fully_filled: bool
+    fills: list[ConsolidatedFill]
+
+
 class BestPrices(TypedDict):
     """Best bid/ask spread"""
     best_bid: int | None
@@ -500,6 +550,68 @@ _EXTENSION_NAMESPACE_ALIASES = {
     "sepolia": "sepolia_bridge",
     "ethereum": "ethereum_bridge",
 }
+
+
+def quote_consolidated_buy_from_book(
+    book: ConsolidatedOrderBook, shares: float, limit_price: float | None = None
+) -> ConsolidatedBuyQuote:
+    """Quote a buy against a book you already hold, with no further chain read.
+
+    A consolidated ladder is not sweepable. ``match_direct`` crosses through
+    the order's limit, but ``match_mint`` and ``match_burn`` only fire when the
+    two prices sum to exactly 100, so an order at limit P fills every native
+    level past P plus exactly ONE inverse level. Summing the ladder overstates
+    what a single order can take, and fillable size does not even grow
+    monotonically with the limit price: raising it can lose the inverse level
+    the fill was counting on.
+
+    The estimate assumes the order reaches the front of the queue at its price.
+    Matching is FIFO within a level, so an older order resting at the same
+    price takes the counterparty first and the real fill comes up short.
+
+    Args:
+        book: A book from :meth:`TNClient.get_consolidated_order_book`. Its
+            ``asks`` are what a buy hits.
+        shares: The size to quote.
+        limit_price: The limit to submit, in cents. Leave it None to have the
+            model choose the cheapest limit that fills the most, which is what
+            a market order wants. Pass a price when something downstream has
+            already settled on one.
+
+    Returns:
+        A ``ConsolidatedBuyQuote``. The model chooses one limit, so the whole
+        order rests at one price rather than sweeping several.
+    """
+    json_str = truf_sdk.QuoteConsolidatedBuyFromBook(
+        json.dumps(book), shares, limit_price if limit_price is not None else 0.0
+    )
+    return cast(ConsolidatedBuyQuote, json.loads(json_str))
+
+
+def quote_consolidated_sell_from_book(
+    book: ConsolidatedOrderBook, shares: float, limit_price: float | None = None
+) -> ConsolidatedSellQuote:
+    """Quote a sell against a book you already hold, with no further chain read.
+
+    Every share pays the submitted limit. A direct match pays the seller the
+    ask price and refunds the buyer the difference, and a burn pays each side
+    its own price, so reaching down the ladder drags every share to the bottom
+    price rather than paying each level its own.
+
+    Args:
+        book: A book from :meth:`TNClient.get_consolidated_order_book`. Its
+            ``bids`` are what a sell hits.
+        shares: The size to quote.
+        limit_price: The limit to submit, in cents. Leave it None to have the
+            model choose the highest limit that fills the most.
+
+    Returns:
+        A ``ConsolidatedSellQuote``.
+    """
+    json_str = truf_sdk.QuoteConsolidatedSellFromBook(
+        json.dumps(book), shares, limit_price if limit_price is not None else 0.0
+    )
+    return cast(ConsolidatedSellQuote, json.loads(json_str))
 
 
 def _normalize_bridge_for_action(bridge_identifier: str) -> str:
@@ -2926,6 +3038,67 @@ class TNClient:
             }
 
         return cast(ConsolidatedOrderBook, json.loads(json_str))
+
+    def quote_consolidated_buy(
+        self,
+        query_id: int,
+        shares: float,
+        outcome: bool = True,
+        limit_price: float | None = None,
+    ) -> ConsolidatedBuyQuote:
+        """Read a market's consolidated book and quote a buy against it.
+
+        Costs one chain read. Hold the book yourself and call
+        :func:`quote_consolidated_buy_from_book` instead when quoting
+        repeatedly, such as a bot re-pricing on every tick.
+
+        See :func:`quote_consolidated_buy_from_book` for what the quote means
+        and why the ladder is not sweepable.
+
+        Args:
+            query_id: The market to read.
+            shares: The size to quote.
+            outcome: The outcome to buy, True=YES.
+            limit_price: The limit to submit, in cents, or None to let the
+                model choose.
+        """
+        json_str = truf_sdk.QuoteConsolidatedBuy(
+            self.client,
+            query_id,
+            outcome,
+            shares,
+            limit_price if limit_price is not None else 0.0,
+        )
+        return cast(ConsolidatedBuyQuote, json.loads(json_str))
+
+    def quote_consolidated_sell(
+        self,
+        query_id: int,
+        shares: float,
+        outcome: bool = True,
+        limit_price: float | None = None,
+    ) -> ConsolidatedSellQuote:
+        """Read a market's consolidated book and quote a sell against it.
+
+        Costs one chain read. Hold the book yourself and call
+        :func:`quote_consolidated_sell_from_book` instead when quoting
+        repeatedly.
+
+        Args:
+            query_id: The market to read.
+            shares: The size to quote.
+            outcome: The outcome to sell, True=YES.
+            limit_price: The limit to submit, in cents, or None to let the
+                model choose.
+        """
+        json_str = truf_sdk.QuoteConsolidatedSell(
+            self.client,
+            query_id,
+            outcome,
+            shares,
+            limit_price if limit_price is not None else 0.0,
+        )
+        return cast(ConsolidatedSellQuote, json.loads(json_str))
 
     def get_best_prices(self, query_id: int, outcome: bool) -> BestPrices:
         """Get current bid/ask spread."""

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -24,6 +24,7 @@ See tests in `tests/test_cache_support.py` for working examples.
 """
 
 import json
+import math
 import warnings
 
 import trufnetwork_sdk_c_bindings.exports as truf_sdk
@@ -576,14 +577,15 @@ def quote_consolidated_buy_from_book(
         limit_price: The limit to submit, in cents. Leave it None to have the
             model choose the cheapest limit that fills the most, which is what
             a market order wants. Pass a price when something downstream has
-            already settled on one.
+            already settled on one. An order can only carry a whole cent from
+            1 through 99, so any other price quotes nothing.
 
     Returns:
         A ``ConsolidatedBuyQuote``. The model chooses one limit, so the whole
         order rests at one price rather than sweeping several.
     """
     json_str = truf_sdk.QuoteConsolidatedBuyFromBook(
-        json.dumps(book), shares, limit_price if limit_price is not None else 0.0
+        json.dumps(book), shares, limit_price if limit_price is not None else math.nan
     )
     return cast(ConsolidatedBuyQuote, json.loads(json_str))
 
@@ -603,13 +605,15 @@ def quote_consolidated_sell_from_book(
             ``bids`` are what a sell hits.
         shares: The size to quote.
         limit_price: The limit to submit, in cents. Leave it None to have the
-            model choose the highest limit that fills the most.
+            model choose the highest limit that fills the most. An order can
+            only carry a whole cent from 1 through 99, so any other price
+            quotes nothing.
 
     Returns:
         A ``ConsolidatedSellQuote``.
     """
     json_str = truf_sdk.QuoteConsolidatedSellFromBook(
-        json.dumps(book), shares, limit_price if limit_price is not None else 0.0
+        json.dumps(book), shares, limit_price if limit_price is not None else math.nan
     )
     return cast(ConsolidatedSellQuote, json.loads(json_str))
 
@@ -3060,14 +3064,15 @@ class TNClient:
             shares: The size to quote.
             outcome: The outcome to buy, True=YES.
             limit_price: The limit to submit, in cents, or None to let the
-                model choose.
+                model choose. An order can only carry a whole cent from 1
+                through 99, so any other price quotes nothing.
         """
         json_str = truf_sdk.QuoteConsolidatedBuy(
             self.client,
             query_id,
             outcome,
             shares,
-            limit_price if limit_price is not None else 0.0,
+            limit_price if limit_price is not None else math.nan,
         )
         return cast(ConsolidatedBuyQuote, json.loads(json_str))
 
@@ -3089,14 +3094,15 @@ class TNClient:
             shares: The size to quote.
             outcome: The outcome to sell, True=YES.
             limit_price: The limit to submit, in cents, or None to let the
-                model choose.
+                model choose. An order can only carry a whole cent from 1
+                through 99, so any other price quotes nothing.
         """
         json_str = truf_sdk.QuoteConsolidatedSell(
             self.client,
             query_id,
             outcome,
             shares,
-            limit_price if limit_price is not None else 0.0,
+            limit_price if limit_price is not None else math.nan,
         )
         return cast(ConsolidatedSellQuote, json.loads(json_str))
 

--- a/tests/test_consolidated_quote.py
+++ b/tests/test_consolidated_quote.py
@@ -1,0 +1,292 @@
+"""Pure unit tests for quoting a fill against a consolidated ladder.
+
+The model lives in sdk-go, and ``quote_consolidated_*_from_book`` reaches it
+through the C extension without touching a node, so these run it for real rather
+than mocking it. What matters is that the ladder is not sweepable: an order at
+limit P takes every native level past P but exactly ONE inverse level, the one at
+P. So fillable size is not monotonic in the limit, the ladder's total is not
+reachable by any single order, and a sell pays its limit on every share.
+
+The client methods are wrappers over the same model, so those are exercised by
+monkeypatching the binding, which is what the wrapper actually owns.
+"""
+
+import json
+
+import pytest
+
+import trufnetwork_sdk_py.client as client_mod
+from trufnetwork_sdk_py.client import (
+    TNClient,
+    quote_consolidated_buy_from_book,
+    quote_consolidated_sell_from_book,
+)
+
+
+def level(price, native, inverse):
+    """One consolidated level, carrying the total the ladder would show."""
+    return {
+        "price": price,
+        "native": native,
+        "inverse": inverse,
+        "total": native + inverse,
+    }
+
+
+def book(bids=(), asks=()):
+    return {
+        "query_id": 419,
+        "outcome": True,
+        "bids": list(bids),
+        "asks": list(asks),
+        "is_crossed": False,
+    }
+
+
+# YES asks 100 @ 60, NO bids 200 @ 41 and 50 @ 45.
+THREE_LEVEL_ASKS = [level(55, 0, 50), level(59, 0, 200), level(60, 100, 0)]
+
+
+# --- buys --------------------------------------------------------------------
+
+
+def test_fills_at_the_one_price_where_the_inverse_leg_is_reachable():
+    quote = quote_consolidated_buy_from_book(book(asks=THREE_LEVEL_ASKS), 100)
+
+    assert quote["limit_price"] == 59
+    assert quote["filled_shares"] == 100
+    assert quote["estimated_total_cost"] == 59
+
+
+def test_reports_the_best_fill_one_order_can_get_not_the_whole_ladder():
+    assert sum(entry["total"] for entry in THREE_LEVEL_ASKS) == 350
+
+    # Summing the ladder says 350. No single order can do better than 200.
+    quote = quote_consolidated_buy_from_book(book(asks=THREE_LEVEL_ASKS), 350)
+
+    assert quote["available_shares"] == 200
+    assert quote["is_fully_filled"] is False
+
+
+def test_does_not_gain_fill_by_raising_the_limit_past_the_inverse_leg():
+    asks = book(asks=[level(59, 0, 200), level(60, 100, 0)])
+
+    # A limit of 60 reaches 100 native shares; a limit of 59 reaches 200 inverse
+    # ones. More fill sits at the lower price.
+    assert quote_consolidated_buy_from_book(asks, 150)["limit_price"] == 59
+    assert quote_consolidated_buy_from_book(asks, 150)["filled_shares"] == 150
+    assert quote_consolidated_buy_from_book(asks, 250)["filled_shares"] == 200
+    assert quote_consolidated_buy_from_book(asks, 250)["limit_price"] == 59
+
+
+def test_prices_native_legs_at_their_own_price_and_the_inverse_leg_at_the_limit():
+    quote = quote_consolidated_buy_from_book(
+        book(asks=[level(20, 40, 0), level(30, 0, 60)]), 100
+    )
+
+    assert quote["limit_price"] == 30
+    assert quote["estimated_total_cost"] == 26
+    assert quote["fills"] == [
+        {"price": 20, "shares": 40, "path": "direct"},
+        {"price": 30, "shares": 60, "path": "mint"},
+    ]
+
+
+def test_averages_the_price_actually_paid_across_both_legs():
+    quote = quote_consolidated_buy_from_book(
+        book(asks=[level(20, 40, 0), level(30, 0, 60)]), 100
+    )
+
+    assert quote["average_price"] == 26
+
+
+# --- sells -------------------------------------------------------------------
+
+
+def test_pays_the_submitted_limit_on_every_share_not_each_bid_its_own_price():
+    # match_direct pays the seller at the ask price, so walking the ladder and
+    # crediting 50 at 80 plus 50 at 70 overstates this by $5.
+    quote = quote_consolidated_sell_from_book(
+        book(bids=[level(80, 50, 0), level(70, 50, 0)]), 100
+    )
+
+    assert quote["limit_price"] == 70
+    assert quote["filled_shares"] == 100
+    assert quote["estimated_proceeds"] == 70
+
+
+def test_combines_a_direct_leg_and_a_burn_leg_at_the_submitted_limit():
+    quote = quote_consolidated_sell_from_book(
+        book(bids=[level(70, 30, 40), level(60, 100, 0)]), 70
+    )
+
+    assert quote["limit_price"] == 70
+    assert quote["filled_shares"] == 70
+    assert quote["estimated_proceeds"] == 49
+    assert quote["fills"] == [
+        {"price": 70, "shares": 30, "path": "direct"},
+        {"price": 70, "shares": 40, "path": "burn"},
+    ]
+
+
+def test_reaches_the_inverse_leg_only_at_the_exact_limit_price():
+    quote = quote_consolidated_sell_from_book(
+        book(bids=[level(65, 0, 80), level(60, 40, 0)]), 80
+    )
+
+    assert quote["limit_price"] == 65
+    assert quote["estimated_proceeds"] == 52
+    assert quote["fills"] == [{"price": 65, "shares": 80, "path": "burn"}]
+
+
+# --- guards and caller-supplied limits ---------------------------------------
+
+
+def test_ignores_levels_outside_the_tradable_range():
+    quote = quote_consolidated_buy_from_book(
+        book(asks=[level(0, 500, 0), level(100, 500, 0), level(40, 60, 0)]), 60
+    )
+
+    assert quote["limit_price"] == 40
+    assert quote["available_shares"] == 60
+
+
+def test_quotes_a_sell_at_the_limit_the_caller_chose():
+    quote = quote_consolidated_sell_from_book(
+        book(bids=[level(80, 50, 0), level(70, 50, 0)]), 100, limit_price=80
+    )
+
+    # Only the 80 bid is reachable at a limit of 80, and it pays 80 a share.
+    assert quote["filled_shares"] == 50
+    assert quote["estimated_proceeds"] == 40
+    assert quote["is_fully_filled"] is False
+
+
+def test_quotes_a_buy_at_the_limit_the_caller_chose():
+    # Left to choose, the model picks 59 for the larger fill. A caller willing to
+    # pay up for the native side gets to say so.
+    quote = quote_consolidated_buy_from_book(
+        book(asks=[level(59, 0, 200), level(60, 100, 0)]), 250, limit_price=60
+    )
+
+    assert quote["limit_price"] == 60
+    assert quote["filled_shares"] == 100
+    assert quote["estimated_total_cost"] == 60
+    assert quote["is_fully_filled"] is False
+
+
+def test_an_empty_book_quotes_nothing():
+    buy = quote_consolidated_buy_from_book(book(), 100)
+    assert buy["limit_price"] is None
+    assert buy["average_price"] is None
+    assert buy["filled_shares"] == 0
+    assert buy["available_shares"] == 0
+    assert buy["fills"] == []
+
+    sell = quote_consolidated_sell_from_book(book(), 100)
+    assert sell["limit_price"] is None
+    assert sell["filled_shares"] == 0
+    assert sell["fills"] == []
+
+
+def test_sorts_an_unordered_ladder_rather_than_trusting_the_input_order():
+    quote = quote_consolidated_buy_from_book(
+        book(asks=[level(60, 100, 0), level(20, 40, 0)]), 40
+    )
+
+    assert quote["limit_price"] == 20
+
+
+# --- mainnet market 419 ------------------------------------------------------
+
+# A frozen snapshot read 2026-08-12 through get_full_market_depth.
+#
+#   YES bids  1c x4283, 3c x1428, 4c x1049
+#   YES asks 16c x320, 17c x324, 19c x289
+#   NO  bids 81c x53,  83c x51,  84c x29
+#   NO  asks 96c x33,  97c x57,  99c x56
+#
+# The NO orders fold into the YES frame at 100 - price, which lands each of them
+# on a price the YES book already quotes.
+MARKET_419 = book(
+    bids=[level(4, 1049, 33), level(3, 1428, 57), level(1, 4283, 56)],
+    asks=[level(16, 320, 29), level(17, 324, 51), level(19, 289, 53)],
+)
+
+
+def test_market_419_one_buy_cannot_take_more_than_the_best_single_price_allows():
+    quote = quote_consolidated_buy_from_book(MARKET_419, 99_999)
+
+    assert quote["available_shares"] == 986
+
+
+def test_market_419_a_buy_inside_native_depth_never_reaches_an_inverse_leg():
+    quote = quote_consolidated_buy_from_book(MARKET_419, 700)
+
+    assert quote["limit_price"] == 19
+    assert quote["estimated_total_cost"] == pytest.approx(116.92)
+    assert all(fill["path"] == "direct" for fill in quote["fills"])
+
+
+def test_market_419_a_sell_past_the_top_bid_pays_its_limit_on_every_share():
+    quote = quote_consolidated_sell_from_book(MARKET_419, 2000)
+
+    # 1049 rest at 4c, but the order only fills in full at a limit of 3c, and
+    # every share then pays 3c. Walking the ladder would have quoted 70.49.
+    assert quote["limit_price"] == 3
+    assert quote["estimated_proceeds"] == pytest.approx(60.0)
+
+
+# --- the client wrappers -----------------------------------------------------
+
+
+def _client_without_connect() -> TNClient:
+    # Bypass __init__ (which would open a network client); the wrapper only
+    # forwards self.client to the (monkeypatched) binding.
+    c = TNClient.__new__(TNClient)
+    c.client = object()
+    return c
+
+
+def test_quote_consolidated_buy_forwards_the_market_and_size(monkeypatch):
+    captured = {}
+
+    def fake_quote(client, query_id, outcome, shares, limit):
+        captured.update(
+            query_id=query_id, outcome=outcome, shares=shares, limit=limit
+        )
+        return json.dumps({"limit_price": 59, "filled_shares": 100})
+
+    monkeypatch.setattr(
+        client_mod.truf_sdk, "QuoteConsolidatedBuy", fake_quote, raising=False
+    )
+
+    quote = _client_without_connect().quote_consolidated_buy(419, 100, outcome=False)
+
+    assert captured == {
+        "query_id": 419,
+        "outcome": False,
+        "shares": 100,
+        "limit": 0.0,
+    }
+    assert quote["limit_price"] == 59
+
+
+def test_quote_consolidated_sell_forwards_a_caller_supplied_limit(monkeypatch):
+    captured = {}
+
+    def fake_quote(client, query_id, outcome, shares, limit):
+        captured["limit"] = limit
+        return json.dumps({"limit_price": limit, "filled_shares": 50})
+
+    monkeypatch.setattr(
+        client_mod.truf_sdk, "QuoteConsolidatedSell", fake_quote, raising=False
+    )
+
+    quote = _client_without_connect().quote_consolidated_sell(
+        419, 50, limit_price=80
+    )
+
+    # No limit means "choose one", so a real price has to survive the hop.
+    assert captured["limit"] == 80
+    assert quote["limit_price"] == 80

--- a/tests/test_consolidated_quote.py
+++ b/tests/test_consolidated_quote.py
@@ -12,6 +12,7 @@ monkeypatching the binding, which is what the wrapper actually owns.
 """
 
 import json
+import math
 
 import pytest
 
@@ -175,6 +176,50 @@ def test_quotes_a_buy_at_the_limit_the_caller_chose():
     assert quote["is_fully_filled"] is False
 
 
+@pytest.mark.parametrize("limit", [0, 100, 19.5, -5])
+def test_rejects_a_limit_no_order_can_carry(limit):
+    # The node declares $price as INT and errors outside 1-99, so none of these
+    # reach the book. Quoting a fill for one would promise an order that cannot
+    # be placed: a buy at 100 otherwise takes every level, and a sell at 0
+    # otherwise fills the whole ladder for nothing.
+    #
+    # 0 matters twice over. It is the value a "no limit given" sentinel would
+    # most naturally use, and it must still be rejected rather than quietly
+    # turned into a limit the model picked.
+    ladder = book(
+        bids=[level(80, 50, 0), level(70, 50, 0)],
+        asks=[level(16, 320, 29), level(19, 289, 53)],
+    )
+
+    buy = quote_consolidated_buy_from_book(ladder, 500, limit_price=limit)
+    assert buy["filled_shares"] == 0
+    assert buy["limit_price"] is None
+    assert buy["estimated_total_cost"] == 0
+    assert buy["is_fully_filled"] is False
+    assert buy["fills"] == []
+
+    # The ladder is still described, so a caller can tell the limit was the
+    # problem rather than the book.
+    assert buy["available_shares"] == 662
+
+    sell = quote_consolidated_sell_from_book(ladder, 100, limit_price=limit)
+    assert sell["filled_shares"] == 0
+    assert sell["estimated_proceeds"] == 0
+    assert sell["fills"] == []
+    assert sell["available_shares"] == 100
+
+
+def test_never_chooses_a_fractional_limit():
+    # A caller can build a ladder carrying a price the chain never produces. The
+    # model must not select one, since the resulting order is rejected.
+    quote = quote_consolidated_buy_from_book(
+        book(asks=[level(19.5, 500, 0), level(40, 60, 0)]), 60
+    )
+
+    assert quote["limit_price"] == 40
+    assert quote["available_shares"] == 60
+
+
 def test_an_empty_book_quotes_nothing():
     buy = quote_consolidated_buy_from_book(book(), 100)
     assert buy["limit_price"] is None
@@ -263,12 +308,12 @@ def test_quote_consolidated_buy_forwards_the_market_and_size(monkeypatch):
 
     quote = _client_without_connect().quote_consolidated_buy(419, 100, outcome=False)
 
-    assert captured == {
-        "query_id": 419,
-        "outcome": False,
-        "shares": 100,
-        "limit": 0.0,
-    }
+    assert captured["query_id"] == 419
+    assert captured["outcome"] is False
+    assert captured["shares"] == 100
+    # No limit given travels as NaN, so 0 stays a real price the model rejects
+    # rather than a sentinel it silently reads as "choose one".
+    assert math.isnan(captured["limit"])
     assert quote["limit_price"] == 59
 
 


### PR DESCRIPTION
`quote_consolidated_buy_from_book` and `quote_consolidated_sell_from_book` answer what an
order of a given size will actually do against a consolidated ladder, so a caller holding
a `ConsolidatedOrderBook` no longer has to re-derive the matching rules.

## Why

The consolidation mapping already reaches Python through sdk-go because it is protocol
semantics. The fill rules are the same category: they are read off `match_direct`,
`match_mint` and `match_burn` in the node's `032-order-book-actions.sql`, they hold for
every consumer, and they change only when the engine changes.

Today they live in one consumer instead. The website carries the model, written against
its own deadline. That is two implementations of one protocol rule, and only one of them
is under SDK tests.

Getting it wrong is easy, because the obvious approach is the wrong one. A consolidated
ladder looks sweepable and is not: `match_direct` crosses through the order's limit, but
mint and burn only fire when the two prices sum to exactly 100, and select the resting
order with `price =` rather than a range. So an order at limit P fills every native level
past P plus exactly **one** inverse level.

## What is in it

The model itself is sdk-go's, as the folding is. Python delegates.

- `quote_consolidated_buy_from_book(book, shares, limit_price=None)` and
  `quote_consolidated_sell_from_book(...)`. Quote a book you already hold, with no
  further chain read. They read the book's `asks` and `bids` respectively, so one read
  answers both directions.
- `client.quote_consolidated_buy(query_id, shares, ...)` and
  `client.quote_consolidated_sell(...)` fetch the book themselves, matching the shape of
  every other binding, at one chain read per quote.
- `ConsolidatedBuyQuote`, `ConsolidatedSellQuote` and `ConsolidatedFill`, whose `path` is
  `"direct"`, `"mint"` or `"burn"` per leg, so a caller can show how the order settles.
- Four bindings in `bindings/bindings.go`, and the sdk-go pin moved forward to pick up
  the model.

Three results the quote makes explicit, each of which a hand-rolled ladder walk gets
wrong:

- **`available_shares` is not the ladder's total.** It is the most any single order can
  take, which is smaller whenever inverse volume rests at more than one price. A ladder
  summing to 350 can cap one order at 200.
- **Fillable size is not monotonic in the limit price.** Raising the limit can lose the
  inverse level the fill was counting on, so the model evaluates every candidate price
  rather than walking down the ladder.
- **A sell pays its limit on every share.** `match_direct` pays the seller the ask price
  and refunds the buyer the difference, so crediting each resting bid its own price
  overstates any sell reaching past one level.

18 tests, none needing a node. The book-in path reaches the real Go model through the C
extension, so these exercise the model rather than a mock — including mainnet market 419
frozen as read on 2026-08-12, checked to the cent. Only the two client wrappers are
monkeypatched, since forwarding is all they own.

`docs/api-reference.md` gains the section.

## What is not in it

**Choosing which limit to submit.** That is routing policy, not protocol. A trading UI
wants the cheapest limit that fills the whole order; a market maker may want the largest
fill, a price ceiling, or the least market impact. Left alone the model applies one
reasonable default, and `limit_price` exists so a different policy is not forced through
it.

**A second implementation in Python.** `forecast.py` keeps pure-Python bucket math and is
untouched; extending it with the fill model would recreate the duplication this removes.

`get_consolidated_order_book` is unchanged.

The quote assumes the order reaches the front of the queue at its price. Matching is FIFO
within a level, so an older order resting at the same price takes the counterparty first
and the real fill comes up short. That caveat is carried in the docstrings.

**Before merging:** `go.mod` pins sdk-go at a commit on its own branch for this PR. It
needs repinning to the sha the sdk-go PR lands on `main`.

- https://github.com/trufnetwork/sdk-go/pull/200

resolves: https://github.com/truflation/website/issues/4502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consolidated order-book quotes for estimated buy and sell fills.
  - Supports quoting from an existing book or fetching the latest market book automatically.
  - Returns fill details, pricing, proceeds, and execution paths.
  - Supports optional price limits and best-available pricing by default.
  - Unavailable prices are represented as `null`.

- **Documentation**
  - Added API documentation covering quote behavior, pricing, liquidity, and fill paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->