### PR TITLE
feat: reflect a consolidated book into the opposite outcome

### DIFF
--- a/bindings/bindings.go
+++ b/bindings/bindings.go
@@ -2643,9 +2643,10 @@ func quoteFills(fills []forecast.ConsolidatedFill) []map[string]any {
 	out := make([]map[string]any, len(fills))
 	for i, fill := range fills {
 		out[i] = map[string]any{
-			"price":  fill.Price,
-			"shares": fill.Shares,
-			"path":   string(fill.Path),
+			"price":       fill.Price,
+			"level_price": fill.LevelPrice,
+			"shares":      fill.Shares,
+			"path":        string(fill.Path),
 		}
 	}
 	return out
@@ -2722,6 +2723,45 @@ func QuoteConsolidatedSellFromBook(bookJSON string, shares, limit float64) (stri
 		return marshalSellQuote(forecast.QuoteConsolidatedSell(bids, shares))
 	}
 	return marshalSellQuote(forecast.QuoteConsolidatedSellAtPrice(bids, shares, limit))
+}
+
+// ReflectConsolidatedBook returns the same market in the opposite outcome's
+// frame, with no second chain read.
+//
+// Both outcome views come from one get_full_market_depth response, so the
+// opposite view is an exact reflection rather than new information: prices
+// complement to 100, bids and asks swap, and native and inverse volume swap with
+// them. Anything rendering both outcomes wants this rather than a second read,
+// which would also risk stitching two moments of the chain into one view.
+func ReflectConsolidatedBook(bookJSON string) (string, error) {
+	var book struct {
+		QueryID int              `json:"query_id"`
+		Outcome bool             `json:"outcome"`
+		Bids    []map[string]any `json:"bids"`
+		Asks    []map[string]any `json:"asks"`
+	}
+	if err := json.Unmarshal([]byte(bookJSON), &book); err != nil {
+		return "", errors.Wrap(err, "failed to parse consolidated order book")
+	}
+
+	reflected := forecast.ReflectConsolidatedBook(forecast.ConsolidatedOrderBook{
+		QueryID: book.QueryID,
+		Outcome: book.Outcome,
+		Bids:    quoteLevels(book.Bids),
+		Asks:    quoteLevels(book.Asks),
+	})
+
+	jsonBytes, err := json.Marshal(map[string]any{
+		"query_id":   reflected.QueryID,
+		"outcome":    reflected.Outcome,
+		"bids":       consolidatedLevels(reflected.Bids),
+		"asks":       consolidatedLevels(reflected.Asks),
+		"is_crossed": reflected.IsCrossed,
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal consolidated order book")
+	}
+	return string(jsonBytes), nil
 }
 
 // QuoteConsolidatedBuy reads a market's consolidated book and quotes a buy

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1541,6 +1541,27 @@ chain and `is_crossed` describes a state the book was really in. Requires a node
 carrying that action. The folding itself runs in sdk-go, so Python, Go and
 TypeScript agree on what a market's executable ladder is.
 
+#### Reflecting a book into the other outcome
+
+`reflect_consolidated_order_book(book)` returns the same market in the opposite
+outcome's frame, with no second chain read.
+
+Both outcome views come from one `get_full_market_depth` response, so the
+opposite view is an exact reflection rather than new information: prices
+complement to 100, bids and asks swap, and native and inverse volume swap with
+them, because a resting order belongs to the other outcome once the frame flips.
+
+```python
+from trufnetwork_sdk_py.client import reflect_consolidated_order_book
+
+yes = client.get_consolidated_order_book(query_id=419, outcome=True)
+no = reflect_consolidated_order_book(yes)
+```
+
+Anything rendering both outcomes wants this rather than a second
+`get_consolidated_order_book` call. It halves the round trips and removes the
+chance of stitching two different moments of the chain into one view.
+
 #### Quoting a fill
 
 Answers what an order of a given size will actually do against a consolidated
@@ -1587,6 +1608,14 @@ ladder walk gets wrong:
 
 `fills` carries each leg's `path` — `"direct"`, `"mint"` or `"burn"` — for
 callers that want to show how the order settles.
+
+Each leg also carries two prices, and they are not the same thing. `price` is
+what a share on that leg pays or receives; `level_price` is the ladder level the
+liquidity rested at. They agree on every buy leg. They diverge on a sell, where
+a direct match pays the seller the submitted limit rather than each resting
+bid's own price, so one order can take three bids and be paid the same on all
+three. Anything rendering which levels an order consumed wants `level_price`;
+anything totalling money wants `price`.
 
 **Choosing the limit is the caller's policy, not the SDK's.** Left to itself the
 model applies one reasonable default: the limit that fills the most, cheapest for

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558
-	github.com/trufnetwork/sdk-go v0.7.6-0.20260814232026-fad42508883f
+	github.com/trufnetwork/sdk-go v0.7.6
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/pkg/errors v0.9.1
 	github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558
-	github.com/trufnetwork/sdk-go v0.7.5
+	github.com/trufnetwork/sdk-go v0.7.6-0.20260814232026-fad42508883f
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 )
 

--- a/go.sum
+++ b/go.sum
@@ -60,10 +60,8 @@ github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558 h1:I49YGUiU
 github.com/trufnetwork/kwil-db v0.10.3-0.20260615121733-0d71bd259558/go.mod h1:LiBAC48uZl2B0IiLtD2hpOce7RNfpuDdghVAOc3u1Qo=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558 h1:m7a9HITFMXJF22QznIKoAdeiH8eZxWPU8IRzgcyNMo8=
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
-github.com/trufnetwork/sdk-go v0.7.5 h1:gSUwhuLjbKBL/O9ZR6NUZaSfQXuW4uA5sc3hVCpRBT8=
-github.com/trufnetwork/sdk-go v0.7.5/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
-github.com/trufnetwork/sdk-go v0.7.6-0.20260814232026-fad42508883f h1:iD92o2G/Tj0wSIkI3X0x7Wy1zDzQXBlCEIGVEZjrucA=
-github.com/trufnetwork/sdk-go v0.7.6-0.20260814232026-fad42508883f/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
+github.com/trufnetwork/sdk-go v0.7.6 h1:H/f+mKMWU9nU4UwPpCcV57ynJlT+PedNNH3diSktVeI=
+github.com/trufnetwork/sdk-go v0.7.6/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558 h1:m7a9
 github.com/trufnetwork/kwil-db/core v0.4.3-0.20260615121733-0d71bd259558/go.mod h1:HnOsh9+BN13LJCjiH0+XKaJzyjWKf+H9AofFFp90KwQ=
 github.com/trufnetwork/sdk-go v0.7.5 h1:gSUwhuLjbKBL/O9ZR6NUZaSfQXuW4uA5sc3hVCpRBT8=
 github.com/trufnetwork/sdk-go v0.7.5/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
+github.com/trufnetwork/sdk-go v0.7.6-0.20260814232026-fad42508883f h1:iD92o2G/Tj0wSIkI3X0x7Wy1zDzQXBlCEIGVEZjrucA=
+github.com/trufnetwork/sdk-go v0.7.6-0.20260814232026-fad42508883f/go.mod h1:CivlBpc5RcYwyo8EysoAZWXXfmTtigfkR5VctivwSHc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/src/trufnetwork_sdk_py/client.py
+++ b/src/trufnetwork_sdk_py/client.py
@@ -310,8 +310,17 @@ class ConsolidatedFill(TypedDict):
     ``direct`` matches an order resting in the same outcome's book. ``mint``
     pairs two buys and ``burn`` pairs two sells, and both need the two prices
     to sum to exactly 100.
+
+    ``price`` is what each share on this leg pays or receives.
+    ``level_price`` is the ladder level the liquidity rested at, and the two
+    differ only on a sell: a direct match pays the seller the submitted limit
+    rather than each resting bid's own price, so one order can take several
+    bids and be paid the same on all of them. Anything showing which levels an
+    order consumed reads ``level_price``; anything totalling money reads
+    ``price``.
     """
     price: float
+    level_price: float
     shares: float
     path: ConsolidatedFillPath
 
@@ -551,6 +560,29 @@ _EXTENSION_NAMESPACE_ALIASES = {
     "sepolia": "sepolia_bridge",
     "ethereum": "ethereum_bridge",
 }
+
+
+def reflect_consolidated_order_book(
+    book: ConsolidatedOrderBook,
+) -> ConsolidatedOrderBook:
+    """Return the same market in the opposite outcome's frame, with no new read.
+
+    Both outcome views come from one ``get_full_market_depth`` response, so the
+    opposite view is an exact reflection rather than new information: prices
+    complement to 100, bids and asks swap, and native and inverse volume swap
+    with them, because a resting order belongs to the other outcome once the
+    frame flips.
+
+    Anything rendering both outcomes wants this rather than a second
+    :meth:`TNClient.get_consolidated_order_book` call. It halves the round trips
+    and removes the chance of stitching two different moments of the chain into
+    one view.
+
+    Args:
+        book: A book from :meth:`TNClient.get_consolidated_order_book`.
+    """
+    json_str = truf_sdk.ReflectConsolidatedBook(json.dumps(book))
+    return cast(ConsolidatedOrderBook, json.loads(json_str))
 
 
 def quote_consolidated_buy_from_book(

--- a/tests/test_consolidated_quote.py
+++ b/tests/test_consolidated_quote.py
@@ -21,6 +21,7 @@ from trufnetwork_sdk_py.client import (
     TNClient,
     quote_consolidated_buy_from_book,
     quote_consolidated_sell_from_book,
+    reflect_consolidated_order_book,
 )
 
 
@@ -88,8 +89,8 @@ def test_prices_native_legs_at_their_own_price_and_the_inverse_leg_at_the_limit(
     assert quote["limit_price"] == 30
     assert quote["estimated_total_cost"] == 26
     assert quote["fills"] == [
-        {"price": 20, "shares": 40, "path": "direct"},
-        {"price": 30, "shares": 60, "path": "mint"},
+        {"price": 20, "level_price": 20, "shares": 40, "path": "direct"},
+        {"price": 30, "level_price": 30, "shares": 60, "path": "mint"},
     ]
 
 
@@ -125,8 +126,8 @@ def test_combines_a_direct_leg_and_a_burn_leg_at_the_submitted_limit():
     assert quote["filled_shares"] == 70
     assert quote["estimated_proceeds"] == 49
     assert quote["fills"] == [
-        {"price": 70, "shares": 30, "path": "direct"},
-        {"price": 70, "shares": 40, "path": "burn"},
+        {"price": 70, "level_price": 70, "shares": 30, "path": "direct"},
+        {"price": 70, "level_price": 70, "shares": 40, "path": "burn"},
     ]
 
 
@@ -137,7 +138,9 @@ def test_reaches_the_inverse_leg_only_at_the_exact_limit_price():
 
     assert quote["limit_price"] == 65
     assert quote["estimated_proceeds"] == 52
-    assert quote["fills"] == [{"price": 65, "shares": 80, "path": "burn"}]
+    assert quote["fills"] == [
+        {"price": 65, "level_price": 65, "shares": 80, "path": "burn"}
+    ]
 
 
 # --- guards and caller-supplied limits ---------------------------------------
@@ -335,3 +338,65 @@ def test_quote_consolidated_sell_forwards_a_caller_supplied_limit(monkeypatch):
     # No limit means "choose one", so a real price has to survive the hop.
     assert captured["limit"] == 80
     assert quote["limit_price"] == 80
+
+
+# --- the resting level on each leg -------------------------------------------
+
+
+def test_a_sell_records_the_bid_it_took_not_just_the_price_it_was_paid():
+    # A sell is paid its limit on every share, so price alone cannot say which
+    # bids the order consumed. Anything rendering "x of y taken at this level"
+    # reads level_price instead.
+    quote = quote_consolidated_sell_from_book(
+        book(bids=[level(80, 50, 0), level(70, 50, 40)]), 140
+    )
+
+    assert quote["limit_price"] == 70
+    assert quote["fills"] == [
+        {"price": 70, "level_price": 80, "shares": 50, "path": "direct"},
+        {"price": 70, "level_price": 70, "shares": 50, "path": "direct"},
+        {"price": 70, "level_price": 70, "shares": 40, "path": "burn"},
+    ]
+    # Every share is paid the limit, so the 80c bid earns 70c here.
+    assert quote["estimated_proceeds"] == 98
+
+
+def test_a_buy_pays_each_level_its_own_price_so_both_agree():
+    quote = quote_consolidated_buy_from_book(
+        book(asks=[level(20, 40, 0), level(30, 0, 60)]), 100
+    )
+
+    for fill in quote["fills"]:
+        assert fill["level_price"] == fill["price"]
+
+
+# --- reflection --------------------------------------------------------------
+
+
+def test_reflection_swaps_the_sides_and_the_native_inverse_split():
+    # A YES ask at 60 holding 10 YES sells and 4 NO buys (resting at 40) is, in
+    # the NO frame, a NO bid at 40 holding those 4 NO buys natively and the 10
+    # YES sells as its inverse.
+    no = reflect_consolidated_order_book(
+        book(asks=[level(60, 10, 4)], bids=[level(30, 20, 0)])
+    )
+
+    assert no["query_id"] == 419
+    assert no["outcome"] is False
+    assert no["bids"] == [{"price": 40, "total": 14, "native": 4, "inverse": 10}]
+    assert no["asks"] == [{"price": 70, "total": 20, "native": 0, "inverse": 20}]
+
+
+def test_reflection_round_trips_back_to_itself():
+    yes = book(
+        asks=[level(16, 320, 29), level(19, 289, 53)],
+        bids=[level(4, 1049, 33), level(1, 4283, 56)],
+    )
+
+    there_and_back = reflect_consolidated_order_book(
+        reflect_consolidated_order_book(yes)
+    )
+
+    assert there_and_back["bids"] == yes["bids"]
+    assert there_and_back["asks"] == yes["asks"]
+    assert there_and_back["outcome"] == yes["outcome"]


### PR DESCRIPTION
`reflect_consolidated_order_book` returns the same market in the opposite outcome's
frame without reading the chain again, and every fill leg now records the ladder level
its liquidity rested at.

## Why

Both came out of building the order-book display on top of the quote model, where the
SDK could not answer two questions it should be able to answer.

**Which levels did the order consume?** A sell is paid its submitted limit on every
share, so `simulateSell` reports every leg at that limit. That is the right number for
money, and it loses the level the liquidity came from: one order taking three bids
reports three legs at one price. Anything rendering "took 50 of the 320 resting here"
could not be built on it, and rebuilding the split in the consumer means
re-implementing best-price-first consumption — the duplication the quote model was
promoted to remove.

**What does the other outcome look like?** Both views come from one
`get_full_market_depth` response, so the opposite view is an exact reflection rather
than new information. Callers were paying a second round trip for it, which also risks
stitching two different moments of the chain into one view.

## What is in it

- `level_price` on every fill, the ladder level the leg rested at, beside `price`,
  which stays what each share pays or receives. They agree on every buy leg and diverge
  on a sell.
- `reflect_consolidated_order_book`, which complements prices to 100, swaps bids with asks, and
  swaps native with inverse volume — the last because a resting order belongs to the
  other outcome once the frame flips.

The model itself is sdk-go's, as always; Python delegates. What is here is the binding
and the wrapper, plus the sdk-go pin moved forward to pick both up.

Four tests, none needing a node: they reach the real Go model through the C extension,
so they exercise the reflection and the new field rather than a mock. One asserts the
reflection round-trips back to the book it started from.

## What is not in it

No change to what fills, what it costs, or which limit the model picks.
Fills gain a field and nothing else moves, so `price` keeps its meaning
for every existing caller.

Three existing tests asserted whole fill literals and now name the new
field. Their expected prices, shares and paths are untouched.

The sdk-go pin is settled: `v0.7.6`, which is the tag on that PR's merge commit, so
nothing here depends on an unmerged branch.

- <https://github.com/trufnetwork/sdk-go/releases/tag/v0.7.6>

Groundwork for the order-book display, which needs both of these. No closing keyword:
the display issue is not this PR's to close.

- <https://github.com/truflation/website/issues/4389>
- <https://github.com/truflation/website/pull/4517>
- <https://github.com/truflation/website/pull/4520>

resolves: https://github.com/truflation/website/issues/4502
